### PR TITLE
column subsetting to deal with tibbles

### DIFF
--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -92,7 +92,7 @@ missRanger <- function(data, maxiter = 10L, pmm.k = 0L, seed = NULL, verbose = 1
       v.na <- data.na[, v]
       
       if (length(completed) == 0L) {
-        data[, v] <- imputeUnivariate(data[, v])
+        data[[v]] <- imputeUnivariate(data[[v]])
       } else {
         fit <- ranger(formula = reformulate(completed, response = v), 
                       data = data[!v.na, union(v, completed)],
@@ -100,7 +100,7 @@ missRanger <- function(data, maxiter = 10L, pmm.k = 0L, seed = NULL, verbose = 1
         pred <- predict(fit, data[v.na, allVars])$predictions
         data[v.na, v] <- if (pmm.k) pmm(xtrain = fit$predictions, 
                                         xtest = pred, 
-                                        ytrain = data[!v.na, v], 
+                                        ytrain = data[[v]][!v.na], 
                                         k = pmm.k) else pred
         predError[[v]] <- fit$prediction.error / (if (fit$treetype == "Regression") var(data[!v.na, v]) else 1)
         


### PR DESCRIPTION
If the `data` is a [tibble](https://github.com/tidyverse/tibble) (from the tidyverse), it can cause errors based how column subsetting differs from standard data.frames. For example, if `data` is a data.frame, then `data[, 1]` returns a vector. If it is a tibble, then it returns a tibble with one column.

This causes the following two errors. First, if all columns have a missing value, then `imputeUnivariate(data[, v])` is expecting the a vector and gets a data frame, as shown in the following reprex.

```
library(missRanger)
#> Warning: package 'missRanger' was built under R version 3.4.4
library(tibble)
#> Warning: package 'tibble' was built under R version 3.4.3
iris_tibble <- as.tibble(iris)

irisWithNA <- generateNA(iris_tibble)
irisImputed <- missRanger(irisWithNA, pmm.k = 3, num.trees = 100)
#> 
#> Missing value imputation by chained tree ensembles
#> 
#> iter 1:  
#> Error: is.atomic(x) is not TRUE
```

Second, when doing PMM, it expects `ytrain = data[!v.na, v]` to be a vector, as shown in the following reprex.

```
library(missRanger)
#> Warning: package 'missRanger' was built under R version 3.4.4
library(tibble)
#> Warning: package 'tibble' was built under R version 3.4.3
iris_tibble <- as.tibble(iris)

irisWithNA <- iris_tibble
irisWithNA[1, 1] <- NA
irisImputed <- missRanger(irisWithNA, pmm.k = 1, num.trees = 100)
#> 
#> Missing value imputation by chained tree ensembles
#> 
#> iter 1:  
#> Error: length(xtrain) == length(ytrain) is not TRUE
```