### PR TITLE
2 changes: allow tibbles explicitly & better error msg

### DIFF
--- a/R/imputeUnivariate.R
+++ b/R/imputeUnivariate.R
@@ -17,8 +17,11 @@
 #' head(imputeUnivariate(generateNA(iris), v = "Species"))
 #' head(imputeUnivariate(generateNA(iris), v = c("Species", "Petal.Length")))
 imputeUnivariate <- function(x, v = NULL, seed = NULL) {
-  stopifnot(is.atomic(x) || is.data.frame(x))
-  
+  if(!is.data.frame(x) && !is_tibble(x) && !is.atomic(x)) {
+    stop('x must be atomic, data frame or tibble\n',
+         '  You have provided an object of class: ', class(x)[1])
+  }
+           
   if (!is.null(seed)) {
     set.seed(seed)  
   }
@@ -38,11 +41,11 @@ imputeUnivariate <- function(x, v = NULL, seed = NULL) {
   if (is.atomic(x)) {
     return(imputeVec(x))
   } 
- 
-  # data frame
+  
+  # data frame or tibble
   v <- if (is.null(v)) names(x) else intersect(v, names(x))
   x[, v] <- lapply(x[, v, drop = FALSE], imputeVec)
-
+  
   x
 }
   


### PR DESCRIPTION
Specifically suggesting:

```{r}
  if(!is.data.frame(x) && !is_tibble(x) && !is.atomic(x)) {
    stop('x must be atomic, data frame or tibble\n',
         '  You have provided an object of class: ', class(x)[1])
  }
```

Explicitly allows tibbles, and also provides a more informative error message to guide the user. Has been tested for each class, as well as when to throw an error. All tests pass. Run the following to test, prior to merging PR, if desired:

```{r}
# bad (expect error)
ag <- cluster::agnes(c(1,2,3,4)) # class "agnes"
summary(imputeUnivariate(ag))

# good (expect *no* error for each class)
## atomic
atomic_random <- c(1,2,3,4,NA)
is.atomic(atomic_random) # correct
summary(imputeUnivariate(atomic_random)) # NA's gone/imputed

## data.frame
df_iris <- missRanger::generateNA(iris, seed = 347)
is.data.frame(df_iris) # correct
summary(imputeUnivariate(df_iris)) # NA's gone/imputed

## tibble/tbl
tbl_iris <- missRanger::generateNA(iris, seed = 347) %>% 
  as_tibble()
is_tibble(tbl_iris) # correct
summary(imputeUnivariate(tbl_iris)) # NA's gone/imputed
```