### PR TITLE
Updating error to explicitly flag/allow tibble

### DIFF
--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -101,6 +101,7 @@ missRanger <- function(data, formula = . ~ ., pmm.k = 0L, maxiter = 10L,
                 "dependent.variable.name", "classification")
   stopifnot(
     "'data' should be a data.frame!" = is.data.frame(data), 
+    "'data' should be a tibble or data.frame!" = is_tibble(data), 
     "'data' should have at least one row and column!" = dim(data) >= 1L, 
     "'formula' should be a formula!" = inherits(formula, "formula"), 
     length(formula <- as.character(formula)) == 3L,


### PR DESCRIPTION
Suggesting: `"'data' should be a tibble or data.frame!" = is_tibble(data), ` in error message, in line with current syntax in this function. Same spirit as PR #34 .