### PR TITLE
Refactor datatype logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
     FNN,
-    ranger,
+    ranger (>= 0.16.0),
     stats,
     utils
 URL: https://github.com/mayer79/missRanger, https://mayer79.github.io/missRanger/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # missRanger 2.6.0
 
+## Possibly breaking changes
+
+- Special columns like date/time can't be imputed anymore. You will need to convert them to numeric before imputation.
+- `pmm()` is much more picky: `xtrain` and `xtest` must both be either numeric, logical, or factor (with identical levels).
+
 ## Minor changes in output object
 
 - Add original data as `data_raw`.
@@ -19,6 +24,7 @@
   - case.weights = NULL
   - num.threads = NULL
   - save.memory = FALSE
+- For variables that can't be used, more information is printed.
 
 # missRanger 2.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,16 @@
+# OUTLOOK for missRanger 3.0.0
+
+## Planned user-visible changes of defaults
+
+- `data_only = FALSE`. For the old API (simply return data), use `data_only = FALSE`.
+- `pmm.k = 3`. For the old behaviour (no PMM), set `pmm.k = 0`.
+
 # missRanger 2.6.0
 
 ## Possibly breaking changes
 
 - Special columns like date/time can't be imputed anymore. You will need to convert them to numeric before imputation.
-- `pmm()` is much more picky: `xtrain` and `xtest` must both be either numeric, logical, or factor (with identical levels).
+- `pmm()` is more picky: `xtrain` and `xtest` must both be either numeric, logical, or factor (with identical levels).
 
 ## Minor changes in output object
 
@@ -13,6 +20,7 @@
 ## Other changes
 
 - More compact vignettes.
+- Better examples.
 - Many relevant `ranger()` arguments are now explicit arguments in `missRanger()` to improve tab-completion experience:
   - num.trees = 500
   - mtry = NULL

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,18 @@
 
 ## Other changes
 
-- Improvement in the vignette on censored data.
-- Explicit arguments passed to `ranger()`:`num.trees = 500`, `min.node.size = NULL`, `max.depth = NULL`, and `num.threads = NULL`. This has the advantage to see it in tab completion.
+- More compact vignettes.
+- Many relevant `ranger()` arguments are now explicit arguments in `missRanger()` to improve tab-completion experience:
+  - num.trees = 500
+  - mtry = NULL
+  - min.node.size = NULL
+  - min.bucket = NULL
+  - max.depth = NULL
+  - replace = TRUE
+  - sample.fraction = if (replace) 1 else 0.632
+  - case.weights = NULL
+  - num.threads = NULL
+  - save.memory = FALSE
 
 # missRanger 2.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 ## Other changes
 
+- Now requires ranger >= 0.16.0.
 - More compact vignettes.
 - Better examples.
 - Many relevant `ranger()` arguments are now explicit arguments in `missRanger()` to improve tab-completion experience:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,8 @@
-# OUTLOOK for missRanger 3.0.0
-
-## Planned user-visible changes of defaults
-
-- `data_only = FALSE`. For the old API (simply return data), use `data_only = FALSE`.
-- `pmm.k = 3`. For the old behaviour (no PMM), set `pmm.k = 0`.
-
 # missRanger 2.6.0
 
 ## Possibly breaking changes
 
-- Special columns like date/time can't be imputed anymore. You will need to convert them to numeric before imputation.
+- Columns of special type like date/time can't be imputed anymore. You will need to convert them to numeric before imputation.
 - `pmm()` is more picky: `xtrain` and `xtest` must both be either numeric, logical, or factor (with identical levels).
 
 ## Minor changes in output object

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## Other changes
 
 - Improvement in the vignette on censored data.
+- Explicit arguments passed to `ranger()`:`num.trees = 500`, `min.node.size = NULL`, `max.depth = NULL`, and `num.threads = NULL`. This has the advantage to see it in tab completion.
 
 # missRanger 2.5.0
 

--- a/R/generateNA.R
+++ b/R/generateNA.R
@@ -4,22 +4,19 @@
 #' 
 #' @param x A vector, matrix or `data.frame`.
 #' @param p Proportion of missing values to add to `x`. In case `x` is a `data.frame`, 
-#'   `p` can also be a vector of probabilities per column or a named vector 
-#'   (see examples).
+#'   `p` can also be a vector of probabilities per column or a named vector.
 #' @param seed An integer seed.
 #' @returns `x` with missing values.
 #' @export
 #' @examples 
-#' generateNA(1:10, p = 0.5, seed = 3345)
-#' generateNA(rep(Sys.Date(), 10))
-#' generateNA(cbind(1:10, 10:1), p = 0.2)
-#' head(generateNA(iris))
+#' generateNA(1:10, p = 0.5)
 #' head(generateNA(iris, p = 0.2))
-#' head(generateNA(iris, p = c(0, 1, 0.5, 0.5, 0.5)))
-#' head(generateNA(iris, p = c(Sepal.Length = 1)))
-#' head(generateNA(iris, p = c(Species = 0.2, Sepal.Length = 0.5)))
 generateNA <- function(x, p = 0.1, seed = NULL) {
-  stopifnot(p >= 0, p <= 1, is.atomic(x) || is.data.frame(x))
+  stopifnot(
+    p >= 0,
+    p <= 1,
+    is.atomic(x) || is.data.frame(x)
+  )
   
   if (!is.null(seed)) {
     set.seed(seed)  
@@ -40,5 +37,6 @@ generateNA <- function(x, p = 0.1, seed = NULL) {
   v <- if (is.null(names(p))) names(x) else intersect(names(p), names(x))
   x[, v] <- Map(generateNaVec, x[, v, drop = FALSE], p)
 
-  x
+  return(x)
 }
+

--- a/R/imputeUnivariate.R
+++ b/R/imputeUnivariate.R
@@ -11,11 +11,7 @@
 #' @export
 #' @examples
 #' imputeUnivariate(c(NA, 0, 1, 0, 1))
-#' imputeUnivariate(c("A", "A", NA))
-#' imputeUnivariate(as.factor(c("A", "A", NA)))
 #' head(imputeUnivariate(generateNA(iris)))
-#' head(imputeUnivariate(generateNA(iris), v = "Species"))
-#' head(imputeUnivariate(generateNA(iris), v = c("Species", "Petal.Length")))
 imputeUnivariate <- function(x, v = NULL, seed = NULL) {
   stopifnot(is.atomic(x) || is.data.frame(x))
   
@@ -43,6 +39,6 @@ imputeUnivariate <- function(x, v = NULL, seed = NULL) {
   v <- if (is.null(v)) names(x) else intersect(v, names(x))
   x[, v] <- lapply(x[, v, drop = FALSE], imputeVec)
 
-  x
+  return(x)
 }
-  
+

--- a/R/methods.R
+++ b/R/methods.R
@@ -34,7 +34,7 @@ summary.missRanger <- function(object, ...) {
   print(object)
   cat("\nSequence of OOB prediction errors:\n\n")
   print(object$pred_errors)
-  cat("\nCorresponding means:\n")
+  cat("\nMean performance per iteration:\n")
   print(object$mean_pred_errors)
   cat("\nFirst rows of imputed data:\n\n")
   print(utils::head(object$data, 3L))

--- a/R/methods.R
+++ b/R/methods.R
@@ -40,3 +40,4 @@ summary.missRanger <- function(object, ...) {
   print(utils::head(object$data, 3L))
   invisible(object)
 }
+

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -284,7 +284,7 @@ missRanger <- function(
           max.depth = max.depth,
           replace = replace,
           sample.fraction = sample.fraction,
-          case.weights = case.weights[!v.na],
+          case.weights = if (!is.null(case.weights)) case.weights[!v.na],
           num.threads = num.threads,
           save.memory = save.memory,
           x = data[!v.na, completed, drop = FALSE],

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -140,8 +140,8 @@ missRanger <- function(
     "Don't load {formula.tools}. It breaks base R's as.character()" = 
       length(formula <- as.character(formula)) == 3L,
     "'pmm.k' should not be negative!" = pmm.k >= 0L,
-    "'maxiter' should be a positiv number!" = maxiter >= 1L,
-    "incompatible ranger arguments" = !(bad_args  %in% names(list(...)))
+    "'maxiter' should be positive!" = maxiter >= 1L,
+    "Incompatible ranger() arguments in ..." = !(bad_args  %in% names(list(...)))
   )
   if (!is.null(case.weights)) {
     stopifnot(

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -120,7 +120,7 @@ missRanger <- function(
     ...
   ) {
   if (verbose) {
-    message("Missing value imputation by random forests\n")
+    message("Missing value imputation by random forests")
   }
   
   # 1) INITIAL CHECKS
@@ -177,17 +177,16 @@ missRanger <- function(
     FUN.VALUE = logical(1L)
   )
   if (verbose && !all(ok)) {
-    message(
-      paste("Can't impute these variables (wrong type): ",
-            paste(to_impute[!ok], collapse = ", "))
+    cat(
+      "\nCan't impute these variables (wrong type): ",
+      paste(to_impute[!ok], collapse = ", ")
     )
   }
   to_impute <- to_impute[ok]
   
   if (length(to_impute) == 0L) {
-    # Nothing to do...
     if (verbose) {
-      cat("\n")
+      message("\nNothing to impute!")
     }
     if (data_only) {
       return(data) 
@@ -218,11 +217,6 @@ missRanger <- function(
   # Variables should either appear in "to_impute" or do not contain any missings
   ok <- impute_by %in% to_impute |
     !vapply(data[, impute_by, drop = FALSE], FUN = anyNA, FUN.VALUE = logical(1L))
-  if (verbose && !all(ok)) {
-    message("Can't use these features for imputation because they contain missing values 
-            and do not appear on the LHS of the formula.")
-    message(paste(impute_by[!ok], collapse = ", "))
-  }  
   impute_by <- impute_by[ok]
   
   # 3b) Drop variables that can't be used as features in ranger()
@@ -232,8 +226,10 @@ missRanger <- function(
     FUN.VALUE = logical(1L)
   )
   if (verbose && !all(ok)) {
-    message("Dropping features of incompatible mode() to impute:")
-    message(paste(impute_by[!ok], collapse = ", "))
+    cat(
+      "\nCan't use these variables for imputation (wrong type): ",
+      paste(impute_by[!ok], collapse = ", ")
+    )
   }
   impute_by <- impute_by[ok]
   
@@ -244,16 +240,17 @@ missRanger <- function(
     FUN.VALUE = logical(1L)
   )
   if (verbose && !all(ok)) {
-    message("Skip constant features for imputation:")
-    message(paste(impute_by[!ok], collapse = ", "))
+    cat(
+      "\nSkip constant features for imputation: ",
+      paste(impute_by[!ok], collapse = ", ")
+    )
   }
   impute_by <- impute_by[ok]
-  
 
   if (verbose) {
-    cat("\n  Variables to impute:\t\t")
+    cat("\nVariables to impute:\t\t")
     cat(to_impute, sep = ", ")
-    cat("\n  Variables used to impute:\t")
+    cat("\nVariables used to impute:\t")
     cat(impute_by, sep = ", ")
     cat("\n")
   }

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -31,7 +31,9 @@
 #' @param num.trees Number of trees passed to [ranger::ranger()].
 #' @param mtry Number of covariates considered per split. The default `NULL` equals
 #'   the rounded down root of the number of features. Can be a function, e.g.,
-#'   `function(p) trunc(p/3)`. Passed to [ranger::ranger()].
+#'   `function(p) trunc(p/3)`. Passed to [ranger::ranger()]. Note that during the
+#'   first iteration, the number of features is growing. Thus, a fixed value can lead to
+#'   an error. Using a function like `function(p) min(p, 2)` will fix such problem.
 #' @param min.node.size Minimal node size passed to [ranger::ranger()].
 #'   By default 1 for classification and 5 for regression.
 #' @param min.bucket Minimal terminal node size passed to [ranger::ranger()].

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -424,7 +424,7 @@ missRanger <- function(
   }
   formula <- as.character(formula)
   if (length(formula) != 3L) {
-    stop("Don't load {formula.tools}. It breaks base R's as.character()")
+    stop("Formula must have left and right hand side. If it has: Don't load {formula.tools}. It breaks base R's as.character()")
   }
   return(lapply(formula[2:3], FUN = .string_parser, data = data))
 }
@@ -440,5 +440,4 @@ missRanger <- function(
   # factor/integer/Date -> "numeric"
   return(mode(x) %in% c("numeric", "character", "logical"))
 }
-
 

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -84,8 +84,7 @@
 #'     http://www.jstatsoft.org/v45/i03/
 #' @export
 #' @examples
-#' set.seed(34)
-#' iris2 <- generateNA(iris)
+#' iris2 <- generateNA(iris, seed = 1)
 #' 
 #' imp1 <- missRanger(iris2, pmm.k = 5, num.trees = 50, seed = 1)
 #' head(imp1)
@@ -93,9 +92,10 @@
 #' # Extended output
 #' imp2 <- missRanger(iris2, pmm.k = 5, num.trees = 50, data_only = FALSE, seed = 1)
 #' summary(imp2)
-#' identical(imp1, imp2$data)  # TRUE
 #' 
-#' # Univariate imputation of Species and Sepal.Width
+#' all.equal(imp1, imp2$data)
+#' 
+#' # Formula interface: Univariate imputation of Species and Sepal.Width
 #' imp3 <- missRanger(iris2, Species + Sepal.Width ~ 1)
 missRanger <- function(
     data,

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -120,7 +120,7 @@ missRanger <- function(
     ...
   ) {
   if (verbose) {
-    message("Missing value imputation by random forests")
+    message("Missing value imputation by random forests\n")
   }
   
   # 1) INITIAL CHECKS
@@ -177,8 +177,10 @@ missRanger <- function(
     FUN.VALUE = logical(1L)
   )
   if (verbose && !all(ok)) {
-    message("Can't impute non-numeric/factor/character/logical features")
-    message(paste(to_impute[!ok], collapse = ", "))
+    message(
+      paste("Can't impute these variables (wrong type): ",
+            paste(to_impute[!ok], collapse = ", "))
+    )
   }
   to_impute <- to_impute[ok]
   

--- a/man/generateNA.Rd
+++ b/man/generateNA.Rd
@@ -10,8 +10,7 @@ generateNA(x, p = 0.1, seed = NULL)
 \item{x}{A vector, matrix or \code{data.frame}.}
 
 \item{p}{Proportion of missing values to add to \code{x}. In case \code{x} is a \code{data.frame},
-\code{p} can also be a vector of probabilities per column or a named vector
-(see examples).}
+\code{p} can also be a vector of probabilities per column or a named vector.}
 
 \item{seed}{An integer seed.}
 }
@@ -22,12 +21,6 @@ generateNA(x, p = 0.1, seed = NULL)
 Takes a vector, matrix or \code{data.frame} and replaces some values by \code{NA}.
 }
 \examples{
-generateNA(1:10, p = 0.5, seed = 3345)
-generateNA(rep(Sys.Date(), 10))
-generateNA(cbind(1:10, 10:1), p = 0.2)
-head(generateNA(iris))
+generateNA(1:10, p = 0.5)
 head(generateNA(iris, p = 0.2))
-head(generateNA(iris, p = c(0, 1, 0.5, 0.5, 0.5)))
-head(generateNA(iris, p = c(Sepal.Length = 1)))
-head(generateNA(iris, p = c(Species = 0.2, Sepal.Length = 0.5)))
 }

--- a/man/imputeUnivariate.Rd
+++ b/man/imputeUnivariate.Rd
@@ -23,9 +23,5 @@ from the non-missing values. For data frames, this sampling is done within colum
 }
 \examples{
 imputeUnivariate(c(NA, 0, 1, 0, 1))
-imputeUnivariate(c("A", "A", NA))
-imputeUnivariate(as.factor(c("A", "A", NA)))
 head(imputeUnivariate(generateNA(iris)))
-head(imputeUnivariate(generateNA(iris), v = "Species"))
-head(imputeUnivariate(generateNA(iris), v = c("Species", "Petal.Length")))
 }

--- a/man/missRanger.Rd
+++ b/man/missRanger.Rd
@@ -45,7 +45,9 @@ predictive mean matching steps. 0 to avoid this step.}
 
 \item{mtry}{Number of covariates considered per split. The default \code{NULL} equals
 the rounded down root of the number of features. Can be a function, e.g.,
-\code{function(p) trunc(p/3)}. Passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+\code{function(p) trunc(p/3)}. Passed to \code{\link[ranger:ranger]{ranger::ranger()}}. Note that during the
+first iteration, the number of features is growing. Thus, a fixed value can lead to
+an error. Using a function like \code{function(p) min(p, 2)} will fix such problem.}
 
 \item{min.node.size}{Minimal node size passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
 By default 1 for classification and 5 for regression.}

--- a/man/missRanger.Rd
+++ b/man/missRanger.Rd
@@ -125,22 +125,19 @@ classification error otherwise. If a variable has been imputed only univariately
 the value is 1.
 }
 \examples{
-irisWithNA <- generateNA(iris, seed = 34)
-irisImputed <- missRanger(irisWithNA, pmm.k = 3, num.trees = 100)
-head(irisImputed)
-head(irisWithNA)
+set.seed(34)
+iris2 <- generateNA(iris)
+
+imp1 <- missRanger(iris2, pmm.k = 5, num.trees = 50, seed = 1)
+head(imp1)
 
 # Extended output
-imp <- missRanger(irisWithNA, pmm.k = 3, num.trees = 50, data_only = FALSE)
-head(imp$data)
-imp$pred_errors
+imp2 <- missRanger(iris2, pmm.k = 5, num.trees = 50, data_only = FALSE, seed = 1)
+summary(imp2)
+identical(imp1, imp2$data)  # TRUE
 
-# If you even want to keep the random forests of the best iteration
-imp <- missRanger(
-  irisWithNA, pmm.k = 3, num.trees = 50, data_only = FALSE, keep_forests = TRUE
-)
-imp$forests$Sepal.Width
-imp$pred_errors[imp$best_iter, "Sepal.Width"]  # 1 - R-squared
+# Univariate imputation of Species and Sepal.Width
+imp3 <- missRanger(iris2, Species + Sepal.Width ~ 1)
 }
 \references{
 \enumerate{

--- a/man/missRanger.Rd
+++ b/man/missRanger.Rd
@@ -9,14 +9,19 @@ missRanger(
   formula = . ~ .,
   pmm.k = 0L,
   num.trees = 500,
+  mtry = NULL,
   min.node.size = NULL,
+  min.bucket = NULL,
   max.depth = NULL,
+  replace = TRUE,
+  sample.fraction = if (replace) 1 else 0.632,
+  case.weights = NULL,
   num.threads = NULL,
+  save.memory = FALSE,
   maxiter = 10L,
   seed = NULL,
   verbose = 1,
   returnOOB = FALSE,
-  case.weights = NULL,
   data_only = TRUE,
   keep_forests = FALSE,
   ...
@@ -38,41 +43,48 @@ predictive mean matching steps. 0 to avoid this step.}
 
 \item{num.trees}{Number of trees passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
 
+\item{mtry}{Number of covariates considered per split. The default \code{NULL} equals
+the rounded down root of the number of features. Can be a function, e.g.,
+\code{function(p) trunc(p/3)}. Passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+
 \item{min.node.size}{Minimal node size passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
 By default 1 for classification and 5 for regression.}
+
+\item{min.bucket}{Minimal terminal node size passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
+The default \code{NULL} means 1.}
 
 \item{max.depth}{Maximal tree depth passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
 \code{NULL} means unlimited depth. 1 means single split trees.}
 
+\item{replace}{Sample with replacement passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+
+\item{sample.fraction}{Fraction of rows per tree passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
+The default: use all rows when \code{replace = TRUE} and 0.632 otherwise.}
+
+\item{case.weights}{Optional case weights passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+
 \item{num.threads}{Number of threads passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
-The default uses all threads.}
+The default \code{NULL} uses all threads.}
 
-\item{maxiter}{Maximum number of chaining iterations.}
+\item{save.memory}{Slow but memory saving mode of \code{\link[ranger:ranger]{ranger::ranger()}}.}
 
-\item{seed}{Integer seed to initialize the random generator.}
+\item{maxiter}{Maximum number of iterations.}
 
-\item{verbose}{Controls how much info is printed to screen.
-0 to print nothing. 1 (default) to print a progress bar per iteration,
-2 to print the OOB prediction error per iteration and variable
-(1 minus R-squared for regression).
-Furthermore, if \code{verbose} is positive, the variables used for imputation are
-listed as well as the variables to be imputed (in the imputation order).
-This will be useful to detect if some variables are unexpectedly skipped.}
+\item{seed}{Integer seed.}
 
-\item{returnOOB}{Logical flag. If TRUE, the final average out-of-bag prediction
-errors per variable is added to the resulting data as attribute "oob".
-Only relevant when \code{data_only = TRUE} (and when forests are grown).}
+\item{verbose}{A value in 0, 1, 2 contolling the verbosity.}
 
-\item{case.weights}{Optional vector with case weights passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+\item{returnOOB}{Should the final average OOB prediction errors be added
+as data attribute "oob"? Only relevant when \code{data_only = TRUE}.}
 
 \item{data_only}{If \code{TRUE} (default), only the imputed data is returned.
 Otherwise, a "missRanger" object with additional information is returned.}
 
-\item{keep_forests}{Should the random forests of the final imputations
+\item{keep_forests}{Should the random forests of the last relevant iteration
 be returned? The default is \code{FALSE}. Setting this option will use a lot of memory.
-Only relevant when \code{data_only = TRUE} (and when forests are grown).}
+Only relevant when \code{data_only = TRUE}.}
 
-\item{...}{Additional arguments passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+\item{...}{Additional arguments passed to \code{\link[ranger:ranger]{ranger::ranger()}}. Not all make sense.}
 }
 \value{
 If \code{data_only = TRUE} an imputed \code{data.frame}. Otherwise, a "missRanger" object
@@ -109,14 +121,6 @@ imputed data is returned.
 OOB prediction errors are quantified as 1 - R^2 for numeric variables, and as
 classification error otherwise. If a variable has been imputed only univariately,
 the value is 1.
-
-A note on \code{mtry}: Be careful when passing a non-default \code{mtry} to
-\code{\link[ranger:ranger]{ranger::ranger()}} because the number of available covariates might be growing during
-the first iteration, depending on the missing pattern.
-Values \code{NULL} (default) and 1 are safe choices.
-Additionally, recent versions of \code{\link[ranger:ranger]{ranger::ranger()}} allow \code{mtry} to be a
-single-argument function of the number of available covariables,
-e.g., \code{mtry = function(m) max(1, m \%/\% 3)}.
 }
 \examples{
 irisWithNA <- generateNA(iris, seed = 34)

--- a/man/missRanger.Rd
+++ b/man/missRanger.Rd
@@ -125,8 +125,7 @@ classification error otherwise. If a variable has been imputed only univariately
 the value is 1.
 }
 \examples{
-set.seed(34)
-iris2 <- generateNA(iris)
+iris2 <- generateNA(iris, seed = 1)
 
 imp1 <- missRanger(iris2, pmm.k = 5, num.trees = 50, seed = 1)
 head(imp1)
@@ -134,9 +133,10 @@ head(imp1)
 # Extended output
 imp2 <- missRanger(iris2, pmm.k = 5, num.trees = 50, data_only = FALSE, seed = 1)
 summary(imp2)
-identical(imp1, imp2$data)  # TRUE
 
-# Univariate imputation of Species and Sepal.Width
+all.equal(imp1, imp2$data)
+
+# Formula interface: Univariate imputation of Species and Sepal.Width
 imp3 <- missRanger(iris2, Species + Sepal.Width ~ 1)
 }
 \references{

--- a/man/missRanger.Rd
+++ b/man/missRanger.Rd
@@ -8,6 +8,10 @@ missRanger(
   data,
   formula = . ~ .,
   pmm.k = 0L,
+  num.trees = 500,
+  min.node.size = NULL,
+  max.depth = NULL,
+  num.threads = NULL,
   maxiter = 10L,
   seed = NULL,
   verbose = 1,
@@ -32,6 +36,17 @@ must appear in the left hand side if they should be used on the right hand side.
 \item{pmm.k}{Number of candidate non-missing values to sample from in the
 predictive mean matching steps. 0 to avoid this step.}
 
+\item{num.trees}{Number of trees passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
+
+\item{min.node.size}{Minimal node size passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
+By default 1 for classification and 5 for regression.}
+
+\item{max.depth}{Maximal tree depth passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
+\code{NULL} means unlimited depth. 1 means single split trees.}
+
+\item{num.threads}{Number of threads passed to \code{\link[ranger:ranger]{ranger::ranger()}}.
+The default uses all threads.}
+
 \item{maxiter}{Maximum number of chaining iterations.}
 
 \item{seed}{Integer seed to initialize the random generator.}
@@ -48,7 +63,7 @@ This will be useful to detect if some variables are unexpectedly skipped.}
 errors per variable is added to the resulting data as attribute "oob".
 Only relevant when \code{data_only = TRUE} (and when forests are grown).}
 
-\item{case.weights}{Vector with non-negative case weights.}
+\item{case.weights}{Optional vector with case weights passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
 
 \item{data_only}{If \code{TRUE} (default), only the imputed data is returned.
 Otherwise, a "missRanger" object with additional information is returned.}
@@ -57,11 +72,7 @@ Otherwise, a "missRanger" object with additional information is returned.}
 be returned? The default is \code{FALSE}. Setting this option will use a lot of memory.
 Only relevant when \code{data_only = TRUE} (and when forests are grown).}
 
-\item{...}{Arguments passed to \code{\link[ranger:ranger]{ranger::ranger()}}. If the data set is large,
-better use less trees (e.g. \code{num.trees = 20}) and/or a low value of
-\code{sample.fraction}. The following arguments are incompatible, amongst others:
-\code{write.forest}, \code{probability}, \code{split.select.weights},
-\code{dependent.variable.name}, and \code{classification}.}
+\item{...}{Additional arguments passed to \code{\link[ranger:ranger]{ranger::ranger()}}.}
 }
 \value{
 If \code{data_only = TRUE} an imputed \code{data.frame}. Otherwise, a "missRanger" object

--- a/man/pmm.Rd
+++ b/man/pmm.Rd
@@ -8,16 +8,15 @@ pmm(xtrain, xtest, ytrain, k = 1L, seed = NULL)
 }
 \arguments{
 \item{xtrain}{Vector with predicted values in the training data.
-Can be of type logical, numeric, character, or factor.}
+Must be numeric, logical, or factor-valued.}
 
 \item{xtest}{Vector as \code{xtrain} with predicted values in the test data.
 Missing values are not allowed.}
 
 \item{ytrain}{Vector of the observed values in the training data. Must be of same
-length as \code{xtrain}. Missing values in either of \code{xtrain} or \code{ytrain} will
-be dropped in a pairwise manner.}
+length as \code{xtrain}.}
 
-\item{k}{Number of nearest neighbours to sample from.}
+\item{k}{Number of nearest neighbours (donors) to sample from.}
 
 \item{seed}{Integer random seed.}
 }
@@ -27,12 +26,9 @@ Vector of the same length as \code{xtest} with values from \code{xtrain}.
 \description{
 For each value in the prediction vector \code{xtest}, one of the closest \code{k}
 values in the prediction vector \code{xtrain} is randomly chosen and its observed
-value in \code{ytrain} is returned.
+value in \code{ytrain} is returned. Note that \code{xtrain} and \code{xtest} must be both either
+numeric, logical, or factor-valued. \code{ytest} can be of any type.
 }
 \examples{
-pmm(xtrain = c(0.2, 0.2, 0.8), xtest = 0.3, ytrain = c(0, 0, 1))
-pmm(xtrain = c(TRUE, FALSE, TRUE), xtest = FALSE, ytrain = c(2, 0, 1))
-pmm(xtrain = c(0.2, 0.8), xtest = 0.3, ytrain = c("A", "B"), k = 2)
-pmm(xtrain = c("A", "A", "B"), xtest = "A", ytrain = c(2, 2, 4), k = 2)
-pmm(xtrain = factor(c("A", "B")), xtest = factor("C"), ytrain = 1:2)
+pmm(xtrain = c(0.2, 0.3, 0.8), xtest = c(0.7, 0.2), ytrain = 1:3, k = 1)  # c(3, 1)
 }

--- a/packaging.R
+++ b/packaging.R
@@ -34,7 +34,7 @@ use_description(
 )
 
 use_package("FNN", "imports")
-use_package("ranger", "Imports")
+use_package("ranger", "Imports", min_version = "0.16.0")
 use_package("stats", "Imports")
 use_package("utils", "Imports")
 

--- a/tests/testthat/test-helper.R
+++ b/tests/testthat/test-helper.R
@@ -1,0 +1,55 @@
+test_that(".formula_parser() works", {
+  expect_error(.formula_parser(~ a))
+  expect_error(.formula_parser("a ~ b"))
+  
+  expect_equal(
+    .formula_parser(. ~ ., data = iris),
+    list(names(iris), names(iris))
+  )
+  
+  expect_equal(
+    .formula_parser(Species + Sepal.Width ~ ., data = iris),
+    list(c("Species", "Sepal.Width"), names(iris))
+  )
+  
+  expect_equal(
+    .formula_parser(. ~ Species + Sepal.Width, data = iris),
+    list(names(iris), c("Species", "Sepal.Width"))
+  )
+  
+  expect_equal(
+    .formula_parser(. ~ . - Species, data = iris),
+    list(names(iris), names(iris[1:4]))
+  )
+  
+  expect_equal(
+    .formula_parser(. - Species ~ ., data = iris),
+    list(names(iris[1:4]), names(iris))
+  )
+  
+  expect_equal(
+    .formula_parser(. - Species ~ . - Species - Sepal.Length, data = iris),
+    list(names(iris[1:4]), names(iris[2:4]))
+  )
+})
+
+test_that(".check_response() works", {
+  expect_true(.check_response(c(1L, 2L)))
+  expect_true(.check_response(c(1.0, 2.0)))
+  expect_true(.check_response(c(TRUE, FALSE)))
+  expect_true(.check_response(LETTERS[1:5]))
+  expect_true(.check_response(factor(LETTERS[1:5])))
+  expect_false(.check_response(as.Date("2009-01-01")))
+  expect_false(.check_response(list(a = 1, b = 2)))
+})
+
+test_that(".check_feature() works", {
+  expect_true(.check_feature(c(1L, 2L)))
+  expect_true(.check_feature(c(1.0, 2.0)))
+  expect_true(.check_feature(c(TRUE, FALSE)))
+  expect_true(.check_feature(LETTERS[1:5]))
+  expect_true(.check_feature(factor(LETTERS[1:5])))
+  expect_true(.check_feature(as.Date("2009-01-01")))
+  expect_false(.check_feature(list(a = 1, b = 2)))
+})
+

--- a/tests/testthat/test-imputeUnivariate.R
+++ b/tests/testthat/test-imputeUnivariate.R
@@ -1,37 +1,36 @@
 test_that("it works for numeric vectors", {
-  x <- c(NA, 1:10, NA)
+  x <- c(NA, c(1.1, 0.2), NA)
   filled <- imputeUnivariate(x)
   expect_true(!anyNA(filled))
-})
-
-test_that("it gives same value for numeric vector", {
-  x <- c(NA, NA, 1:10)
-  filled <- imputeUnivariate(x, seed = 1L)
-  expect_equal(filled[1:2], c(9L, 4L))
+  expect_true(is.numeric(filled))
 })
 
 test_that("it works for character vectors", {
   x <- c(LETTERS[1:10], NA, NA)
   filled <- imputeUnivariate(x)
   expect_true(!anyNA(filled))
+  expect_true(is.character(filled))
 })
 
 test_that("it works for factors", {
   x <- factor(c(LETTERS[1:10], NA, NA))
   filled <- imputeUnivariate(x)
   expect_true(!anyNA(filled))
+  expect_true(is.factor(filled))
 })
 
-test_that("it works for boolean vectors", {
+test_that("it works for logical vectors", {
   x <- c(TRUE, TRUE, FALSE, NA, NA)
   filled <- imputeUnivariate(x)
   expect_true(!anyNA(filled))
+  expect_true(is.logical(filled))
 })
 
 test_that("it works for date vectors", {
   x <- generateNA(rep(Sys.Date(), 10L), p = 0.5)
   filled <- imputeUnivariate(x)
   expect_true(!anyNA(filled))
+  expect_s3_class(filled, "Date")
 })
 
 test_that("it works for matrix objects", {
@@ -46,7 +45,7 @@ test_that("it works for data.frames", {
   expect_true(!anyNA(filled))
 })
 
-test_that("it can impute only certain columns", {
+test_that("it can impute subset of all columns", {
   x <- generateNA(iris, seed = 10L)
   filled <- imputeUnivariate(x, v = c("Species", "Petal.Length"))
   expect_true(!anyNA(filled[["Species"]]))

--- a/tests/testthat/test-missRanger.R
+++ b/tests/testthat/test-missRanger.R
@@ -1,260 +1,448 @@
-irisWithNA <- generateNA(iris, seed = 1, p = 0.3)
+iris2 <- generateNA(iris, seed = 1, p = 0.3)
 
-test_that("all missings are filled", {
-  imp <- missRanger(irisWithNA, pmm.k = 3L, verbose = 0L, seed = 1L, num.trees = 5L)
-  expect_true(!anyNA(imp))
+test_that("all missings are filled for multivariate and univariate imputation", {
+  imp <- missRanger(iris2, verbose = 0L, seed = 1L, num.trees = 20L, data_only = FALSE)
+  expect_true(imp$best_iter > 1L)
+  expect_true(!anyNA(imp$data))
+  
+  imp <- missRanger(iris2, . ~ 1, verbose = 0L, seed = 1L, data_only = FALSE)
+  expect_equal(imp$best_iter, 1L)
+  expect_true(!anyNA(imp$data))
 })
 
-test_that("pmm.k works", {
+#===================================================
+# ARGUMENTS
+#===================================================
+
+test_that("pmm.k produces values in the original data", {
   imp1 <- missRanger(
-    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, pmm.k = 0L, seed = 1L
+    iris2, num.trees = 20L, verbose = 0L, pmm.k = 0L, seed = 1L, data_only = FALSE
   )
   imp2 <- missRanger(
-    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, pmm.k = 3L, seed = 1L
+    iris2, num.trees = 20L, verbose = 0L, pmm.k = 3L, seed = 1L, data_only = FALSE
   )
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
-  expect_false(all(imp1$Sepal.Length %in% irisWithNA$Sepal.Length))
-  expect_true(all(imp2$Sepal.Length %in% irisWithNA$Sepal.Length))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
+  expect_true(all(imp2$data$Sepal.Length %in% iris2$Sepal.Length))
 })
 
 test_that("num.trees has an effect", {
-  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(irisWithNA, num.trees = 20L, verbose = 0L, seed = 1L)
+  imp1 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  imp2 <- missRanger(iris2, num.trees = 10L, verbose = 0L, seed = 1L, data_only = FALSE)
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
 })
 
 test_that("mtry has an effect", {
-  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, mtry = 1)
+  imp1 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  imp2 <- missRanger(
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, mtry = 1, data_only = FALSE
+  )
   imp3 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, mtry = function(m) min(m, 4)
+    iris2,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    mtry = function(m) min(m, 4),
+    data_only = FALSE
   )
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
-  expect_false(isTRUE(all.equal(imp1, imp3)))
-  expect_false(isTRUE(all.equal(imp2, imp3)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
+  expect_false(isTRUE(all.equal(imp1$data, imp3$data)))
+  expect_false(isTRUE(all.equal(imp2$data, imp3$data)))
 })
 
 test_that("min.node.size has an effect", {
   imp1 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.node.size = 10
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, min.node.size = 10, data_only = FALSE
   )
   imp2 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.node.size = 20
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, min.node.size = 20, data_only = FALSE
   )
 
-  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
 })
 
 test_that("min.bucket has an effect", {
   imp1 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.bucket = 10
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, min.bucket = 10, data_only = FALSE
   )
   imp2 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.bucket = 20
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, min.bucket = 20, data_only = FALSE
   )
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
 })
 
 test_that("max.depth has an effect", {
   imp1 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, max.depth = 1
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, max.depth = 1, data_only = FALSE
   )
   imp2 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, max.depth = 2
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, max.depth = 2, data_only = FALSE
   )
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
 })
 
 test_that("replace has an effect", {
   imp1 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, replace = TRUE
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, replace = TRUE, data_only = FALSE
   )
   imp2 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, replace = FALSE
+    iris2, num.trees = 20L, verbose = 0L, seed = 1L, replace = FALSE, data_only = FALSE
   )
   
-  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
 })
 
 test_that("sample.fraction has an effect", {
   imp1 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, sample.fraction = 1
-  )
-  imp2 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, sample.fraction = 0.5
-  )
-  
-  expect_false(isTRUE(all.equal(imp1, imp2)))
-})
-
-test_that("case.weights works", {
-  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(
-    irisWithNA,
-    num.trees = 10L,
+    iris2,
+    num.trees = 20L,
     verbose = 0L,
     seed = 1L,
-    case.weights = rep(1, nrow(iris))
+    sample.fraction = 1,
+    data_only = FALSE
   )
-  imp3 <- missRanger(
-    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, case.weights = 1:nrow(iris)
+  imp2 <- missRanger(
+    iris2,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    sample.fraction = 0.5,
+    data_only = FALSE
   )
   
-  expect_true(isTRUE(all.equal(imp1, imp2)))
-  expect_false(isTRUE(all.equal(imp1, imp3)))
-  expect_error(missRanger(irisWithNA, num.trees = 3L, verbose = 0L, case.weights = 1:7))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  
+  expect_false(isTRUE(all.equal(imp1$data, imp2$data)))
+})
+
+test_that("case.weights works (only if multivariate imputation is being done)", {
+  imp1 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  imp2 <- missRanger(
+    iris2,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    case.weights = rep(1, nrow(iris)),
+    data_only = FALSE
+  )
+  imp3 <- missRanger(
+    iris2,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    case.weights = 1:nrow(iris),
+    data_only = FALSE
+  )
+  
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter > 1L)
+  
+  expect_equal(imp1$data, imp2$data)
+  expect_false(isTRUE(all.equal(imp1$data, imp3$data)))
+  
+  expect_error(missRanger(iris2, num.trees = 3L, verbose = 0L, case.weights = 1:7))
 })
 
 test_that("seed works", {
-  imp1 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
-  imp3 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 2L)
+  imp1 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  imp2 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  imp3 <- missRanger(iris2, num.trees = 20L, verbose = 0L, seed = 2L, data_only = FALSE)
   
-  expect_equal(imp1, imp2)
-  expect_false(identical(imp1, imp3))
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter > 1L)
+  
+  expect_equal(imp1$data, imp2$data)
+  expect_false(identical(imp1$data, imp3$data))
 })
 
 test_that("verbose can be suppressed", {
-  expect_silent(missRanger(irisWithNA, num.trees = 3L, maxiter = 3L, verbose = 0L))
+  expect_silent(missRanger(iris2, num.trees = 3L, verbose = 0L))
 })
 
 test_that("returnOOB works", {
   imp1 <- missRanger(
-    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, returnOOB = TRUE
+    iris2, num.trees = 20L, verbose = 0L, returnOOB = TRUE
   )
   imp2 <- missRanger(
-    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, returnOOB = FALSE
+    iris2, num.trees = 20L, verbose = 0L, returnOOB = FALSE
   )
   
   expect_true(length(attributes(imp1)$oob) == ncol(iris))
   expect_null(attributes(imp2)$oob)
 })
 
-
-# DATA TYPE CHECKS
+#===================================================
+# DATA TYPE CONSISTENCY
+#===================================================
 
 n <- 200L
+
 X <- data.frame(
-  x1 = seq_len(n), 
-  x2 = log(seq_len(n)), 
-  x3 = rep(LETTERS[1:4], n %/% 4),
-  x4 = factor(rep(LETTERS[1:2], n %/% 2)),
-  x5 = seq_len(n) > n %/% 3
+  int = seq_len(n), 
+  double = log(seq_len(n)), 
+  char = rep(LETTERS[1:4], n %/% 4),
+  fact = factor(rep(LETTERS[1:2], n %/% 2)),
+  logi = seq_len(n) > n %/% 3,
+  date = seq.Date(as.Date("2001-01-01"), length.out = n, by = "1 d")
 )
 
-X_NA <- generateNA(X, p = seq(0.2, 0.8, length.out = ncol(X)), seed = 13L)
+X_NA <- generateNA(X[1:5], p = 0.2, seed = 1L)
 
-test_that("Special columns like dates can't be filled but work as features", {
-  ir1 <- transform(
-    iris[1:2], 
-    date = seq.Date(as.Date("2001-01-01"), length.out = nrow(iris), by = "1 d")
-  ) |> 
-    generateNA()
-  
- # TODO
- # expect_error(missRanger(ir1, maxiter = 3L, num.trees = 5L, verbose = 0L))
-  
-  ir2 <- transform(
-    irisWithNA[1:2],
-    date = seq.Date(as.Date("2001-01-01"), length.out = nrow(iris), by = "1 d")
-  )
+test_that("Imputing a logical produces a logical (normal, pmm, univariate)", {
+  X2 <- generateNA(X, p = c(logi = 0.3), seed = 1L)
   
   imp1 <- missRanger(
-    ir2,
-    maxiter = 3L,
-    num.trees = 20L,
-    verbose = 0L,
-    seed = 1L,
-    data_only = FALSE,
-    mtry = 1
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 0, seed = 1L, data_only = FALSE
   )
   imp2 <- missRanger(
-    ir2, 
-    . ~ . - Sepal.Width,
-    maxiter = 3L,
-    num.trees = 20L,
-    verbose = 0L,
-    seed = 1L,
-    data_only = FALSE,
-    mtry = 1
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 3, seed = 1L, data_only = FALSE
+  )
+  imp3 <- missRanger(X2, . ~ 1, verbose = 0L, seed = 1L, data_only = FALSE)
+
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter == 1L)
+    
+  for (imp in list(imp1, imp2, imp3)) {
+    expect_true(is.logical(imp$data$logi))
+  }
+})
+
+test_that("Imputing a factor produces a factor (normal, pmm, univariate)", {
+  X2 <- generateNA(X, p = c(fact = 0.3))
+  imp1 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 0, seed = 1L, data_only = FALSE
+  )
+  imp2 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 3, seed = 1L, data_only = FALSE
+  )
+  imp3 <- missRanger(X2, . ~ 1, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter == 1L)
+  
+  for (imp in list(imp1, imp2, imp3)) {
+    expect_true(is.factor(imp$data$fact))
+    expect_equal(levels(imp$data$fact), levels(X$fact))
+  }
+})
+
+test_that("Imputing a character produces a character (normal, pmm, univariate)", {
+  X2 <- generateNA(X, p = c(char = 0.3))
+  imp1 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 0, seed = 1L, data_only = FALSE
+  )
+  imp2 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 3, seed = 1L, data_only = FALSE
+  )
+  imp3 <- missRanger(X2, . ~ 1, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter == 1L)
+  
+  for (imp in list(imp1, imp2, imp3)) {
+    expect_true(is.character(imp$data$char))
+  }
+})
+
+test_that("Imputing a int produces an int or double (normal, pmm, univariate)", {
+  X2 <- generateNA(X, p = c(int = 0.3), seed = 1L)
+  
+  imp1 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 0, seed = 1L, data_only = FALSE
+  )
+  imp2 <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, pmm.k = 3, seed = 1L, data_only = FALSE
+  )
+  imp3 <- missRanger(X2, . ~ 1, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_true(imp1$best_iter > 1L)
+  expect_true(imp2$best_iter > 1L)
+  expect_true(imp3$best_iter == 1L)
+  
+  for (imp in list(imp1, imp2, imp3)) {
+    expect_true(is.numeric(imp$data$int))
+  }
+})
+
+# SELECTION OF "to_impute" and "impute_by"
+
+# Are two vectors identical up to sorting?
+.setequal <- function(x, y) {
+  (length(x) == length(y)) && all(sort(x) == sort(y))
+}
+
+test_that("Only features with missings, but not all missings, are being imputed", {
+  X2 <- generateNA(X, p = c(int = 1, double = 0.2), seed = 1L)
+  imp <- missRanger(X2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_equal(imp$to_impute, "double")
+  expect_equal(unname(colSums(is.na(imp$data))), c(n, 0, 0, 0, 0, 0))
+})
+
+test_that("Date variables (and other non-standard variable types) are not imputed", {
+  X2 <- generateNA(X, p = c(date = 0.3, int = 0.1), seed = 1L)
+  imp <- missRanger(X2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_equal(imp$to_impute, "int")
+  expect_true(anyNA(imp$data$date))
+})
+
+test_that("Features with missings that are not imputed are not used for imputation", {
+  X2 <- generateNA(X, p = c(int = 0.1, double = 0.2), seed = 1L)
+  imp <- missRanger(
+    X2, . - double ~ ., num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE
   )
   
-  expect_false(identical(imp1$data, imp2$data))
-  expect_equal(sort(imp1$to_impute), c("Sepal.Length", "Sepal.Width"))
-  expect_equal(sort(imp2$to_impute), c("Sepal.Length", "Sepal.Width"))
-  expect_equal(imp1$impute_by, c("Sepal.Length", "Sepal.Width", "date"))
-  expect_equal(imp2$impute_by, c("Sepal.Length", "date"))
+  expect_equal(imp$impute_by, setdiff(colnames(X2), "double"))
+})
+
+test_that("Constant features are not used for imputation", {
+  X2 <- generateNA(X, p = c(int = 0.1, double = 0.2), seed = 1L) |> 
+    transform(const = 1)
+  imp <- missRanger(
+    X2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE
+  )
+  
+  expect_equal(imp$impute_by, setdiff(colnames(X2), "const"))
+})
+
+test_that("list variables (and other strange types) cannot be used for imputation", {
+  X2 <- generateNA(X, p = c(int = 0.1, double = 0.2), seed = 1L)
+  X2$list <- as.list(replicate(n, NULL))
+  imp <- missRanger(X2, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE)
+  
+  expect_equal(imp$impute_by, setdiff(colnames(X), "list"))
+})
+
+test_that("Multiple problems together", {
+  X2 <- generateNA(X, p = 0.2, seed = 1L)
+  X2$list <- as.list(replicate(n, NULL))
+  X2$const <- 1
+  
+  imp <- missRanger(
+    X2, . - double ~ ., num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE
+  )
+  
+  xpected <- setdiff(colnames(X), c("double", "date"))  
+  expect_equal(imp$impute_by, xpected)
+  expect_true(.setequal(imp$to_impute, xpected))
 })
 
 # FORMULA PARSING
+
 test_that("formula interface works with specified left and right side", {
   imp <- missRanger(
-    X_NA, x2 ~ x2 + x3, pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+    X_NA,
+    int ~ int + double,
+    pmm = 3L,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    data_only = FALSE
   )
   na_per_col <- colSums(is.na(imp$data))
   
-  expect_equal(na_per_col[[2L]], 0L)
-  expect_true(all(na_per_col[-2L] >= 1L))
-  expect_equal(imp$to_impute, "x2")
-  expect_equal(imp$impute_by, "x2")
+  expect_equal(na_per_col[[1L]], 0L)
+  expect_true(all(na_per_col[-1L] >= 1L))
+  expect_equal(imp$to_impute, "int")
+  expect_equal(imp$impute_by, "int")
 })
 
 test_that("formula interface works with unspecified right side", {
   imp <- missRanger(
-    X_NA, x2 + x3 ~ ., pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+    X_NA,
+    int + double ~ .,
+    pmm = 3L,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    data_only = FALSE
   )
   na_per_col <- colSums(is.na(imp$data))
   
-  expect_equal(unname(na_per_col[2:3]), c(0, 0))
-  expect_true(all(na_per_col[-c(2:3)] >= 1L))
-  expect_equal(sort(imp$to_impute), c("x2", "x3"))
-  expect_equal(sort(imp$impute_by), c("x2", "x3"))
+  expect_equal(unname(na_per_col[1:2]), c(0, 0))
+  expect_true(all(na_per_col[-(1:2)] >= 1L))
+  expect_true(.setequal(imp$to_impute, c("int", "double")))
+  expect_equal(imp$impute_by, c("int", "double"))
 })
 
 test_that("formula interface works with unspecified left side", {
   imp <- missRanger(
-    X_NA, . ~ x1, pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+    X_NA, . ~ int, pmm = 3L, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE
   )
   expect_true(!anyNA(imp$data))
-  expect_equal(sort(imp$to_impute), sort(colnames(X_NA)))
-  expect_equal(imp$impute_by, "x1")
+  expect_true(.setequal(imp$to_impute, colnames(X_NA)))
+  expect_equal(imp$impute_by, "int")
 })
 
-test_that("dropping columns on left side leave missing values", {
+test_that("dropping columns on left side leaves missing values", {
   imp <- missRanger(
-    X_NA, . - x1 ~ ., pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+    X_NA,
+    . - int ~ .,
+    pmm = 3L,
+    num.trees = 20L,
+    verbose = 0L,
+    seed = 1L,
+    data_only = FALSE
   )
   expect_equal(
-    colSums(is.na(imp$data)) > 0,
-    c(x1 = TRUE, x2 = FALSE, x3 = FALSE, x4 = FALSE, x5 = FALSE)
+    unname(colSums(is.na(imp$data)) > 0),
+    c(TRUE, FALSE, FALSE, FALSE, FALSE)
   )
-  xpected <- setdiff(colnames(X_NA), "x1")
-  expect_equal(sort(imp$to_impute), sort(xpected))
+  xpected <- setdiff(colnames(X_NA), "int")
+  expect_true(.setequal(imp$to_impute, xpected))
   expect_equal(imp$impute_by, xpected)
 })
 
 test_that("dropping columns on right side has an impact", {
   imp1 <- missRanger(
-    X_NA, . ~ . - x1, num.trees = 5L, verbose = 0L, seed = 1L, data_only = FALSE
+    X_NA, . ~ . - int, num.trees = 20L, verbose = 0L, seed = 1L, data_only = FALSE
   )
-  imp2 <- missRanger(X_NA, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(X_NA, num.trees = 20L, verbose = 0L, seed = 1L)
   
   expect_false(identical(imp1$data, imp2))
-  expect_equal(sort(imp1$to_impute), sort(colnames(X_NA)))
-  expect_equal(imp1$impute_by, setdiff(colnames(X_NA), "x1"))
+  expect_true(.setequal(imp1$to_impute, colnames(X_NA)))
+  expect_equal(imp1$impute_by, setdiff(colnames(X_NA), "int"))
 })
 
 test_that("empty rhs equals univariate imputation", {
-  imp1 <- missRanger(X_NA, . ~ 1, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp1 <- missRanger(X_NA, . ~ 1, num.trees = 20L, verbose = 0L, seed = 1L)
   imp2 <- imputeUnivariate(X_NA, seed = 1L)
 
-  imp3 <- missRanger(X_NA, x1 + x2 ~ 1, num.trees = 5L, verbose = 0L, seed = 1L)
-  imp4 <- imputeUnivariate(X_NA, seed = 1L, v = c("x1", "x2"))
+  imp3 <- missRanger(X_NA, int + char ~ 1, num.trees = 20L, verbose = 0L, seed = 1L)
+  imp4 <- imputeUnivariate(X_NA, seed = 1L, v = c("int", "char"))
   
   expect_equal(imp1, imp2)
   expect_equal(imp3, imp4)
@@ -262,54 +450,19 @@ test_that("empty rhs equals univariate imputation", {
 
 test_that("non-syntactic column names work with or without formula", {
   X_NA2 <- X_NA
-  colnames(X_NA2) <- paste(1:5, colnames(X_NA))
+  colnames(X_NA2)[1:2] <- c("1bad name", "2 also bad")
   
-  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(X_NA2, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp1 <- missRanger(X_NA, num.trees = 20L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(X_NA2, num.trees = 20L, verbose = 0L, seed = 1L)
   imp3 <- missRanger(
-    `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5` ~ `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5`,
-    data = X_NA2, 
-    maxiter = 3L, 
-    num.trees = 5L, 
-    verbose = 0L, 
-    seed = 1L
-  )
-  
-  imp4 <- missRanger(
-    . ~ `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5`,
-    data = X_NA2, 
-    maxiter = 3L, 
-    num.trees = 5L, 
-    verbose = 0L, 
-    seed = 1L
-  )
-  
-  imp5 <- missRanger(
-    `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5` ~ .,
-    data = X_NA2, 
-    maxiter = 3L, 
-    num.trees = 5L, 
-    verbose = 0L, 
-    seed = 1L
-  )
-  
-  imp6 <- missRanger(
-    . - `1 x1` ~ . - `1 x1`,
-    data = X_NA2, 
-    maxiter = 3L, 
-    num.trees = 5L, 
-    verbose = 0L, 
-    seed = 1L
+    . - `1bad name` ~ - ., data = X_NA2, num.trees = 20L, verbose = 0L, seed = 1L
   )
   
   expect_equal(colnames(X_NA2), colnames(imp2))
-  expect_equal(imp, setNames(imp2, colnames(imp)))
-  expect_equal(imp2, imp3)
-  expect_equal(imp2, imp4)
-  expect_equal(imp2, imp5)
-  
+  expect_equal(imp1, setNames(imp2, colnames(imp1)))
+  expect_false(anyNA(imp2))
   expect_equal(
-    unname(colSums(is.na(imp6)) == 0L),
+    unname(colSums(is.na(imp3)) == 0L),
     c(FALSE, TRUE, TRUE, TRUE, TRUE)
   )
 })

--- a/tests/testthat/test-missRanger.R
+++ b/tests/testthat/test-missRanger.R
@@ -186,6 +186,8 @@ test_that("seed works", {
 
 test_that("verbose can be suppressed", {
   expect_silent(missRanger(iris2, num.trees = 3L, verbose = 0L))
+  capture_output(expect_message(missRanger(iris2, num.trees = 3L, verbose = 1L)))
+  capture_output(expect_message(missRanger(iris2, num.trees = 3L, verbose = 2L)))
 })
 
 test_that("returnOOB works", {

--- a/tests/testthat/test-missRanger.R
+++ b/tests/testthat/test-missRanger.R
@@ -220,7 +220,7 @@ X <- data.frame(
 X_NA <- generateNA(X[1:5], p = 0.2, seed = 1L)
 
 test_that("Imputing a logical produces a logical (normal, pmm, univariate)", {
-  X2 <- generateNA(X, p = c(logi = 0.3), seed = 1L)
+  X2 <- generateNA(X, p = c(logi = 0.3, fact = 0.3), seed = 1L)
   
   imp1 <- missRanger(
     X2, num.trees = 20L, verbose = 0L, pmm.k = 0, seed = 1L, data_only = FALSE

--- a/tests/testthat/test-missRanger.R
+++ b/tests/testthat/test-missRanger.R
@@ -5,23 +5,149 @@ test_that("all missings are filled", {
   expect_true(!anyNA(imp))
 })
 
-test_that("messages are suppressed with verbose=0", {
-  expect_silent(missRanger(irisWithNA, maxiter = 3L, num.trees = 50L, verbose = 0L))
+test_that("pmm.k works", {
+  imp1 <- missRanger(
+    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, pmm.k = 0L, seed = 1L
+  )
+  imp2 <- missRanger(
+    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, pmm.k = 3L, seed = 1L
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_false(all(imp1$Sepal.Length %in% irisWithNA$Sepal.Length))
+  expect_true(all(imp2$Sepal.Length %in% irisWithNA$Sepal.Length))
+})
+
+test_that("num.trees has an effect", {
+  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(irisWithNA, num.trees = 20L, verbose = 0L, seed = 1L)
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("mtry has an effect", {
+  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, mtry = 1)
+  imp3 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, mtry = function(m) min(m, 4)
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+  expect_false(isTRUE(all.equal(imp1, imp3)))
+  expect_false(isTRUE(all.equal(imp2, imp3)))
+})
+
+test_that("min.node.size has an effect", {
+  imp1 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.node.size = 10
+  )
+  imp2 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.node.size = 20
+  )
+
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("min.bucket has an effect", {
+  imp1 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.bucket = 10
+  )
+  imp2 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, min.bucket = 20
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("max.depth has an effect", {
+  imp1 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, max.depth = 1
+  )
+  imp2 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, max.depth = 2
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("replace has an effect", {
+  imp1 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, replace = TRUE
+  )
+  imp2 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, replace = FALSE
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("sample.fraction has an effect", {
+  imp1 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, sample.fraction = 1
+  )
+  imp2 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, sample.fraction = 0.5
+  )
+  
+  expect_false(isTRUE(all.equal(imp1, imp2)))
+})
+
+test_that("case.weights works", {
+  imp1 <- missRanger(irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(
+    irisWithNA,
+    num.trees = 10L,
+    verbose = 0L,
+    seed = 1L,
+    case.weights = rep(1, nrow(iris))
+  )
+  imp3 <- missRanger(
+    irisWithNA, num.trees = 10L, verbose = 0L, seed = 1L, case.weights = 1:nrow(iris)
+  )
+  
+  expect_true(isTRUE(all.equal(imp1, imp2)))
+  expect_false(isTRUE(all.equal(imp1, imp3)))
+  expect_error(missRanger(irisWithNA, num.trees = 3L, verbose = 0L, case.weights = 1:7))
 })
 
 test_that("seed works", {
-  imp1 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 50L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 50L, verbose = 0L, seed = 1L)
+  imp1 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp3 <- missRanger(irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 2L)
+  
   expect_equal(imp1, imp2)
+  expect_false(identical(imp1, imp3))
+})
+
+test_that("verbose works", {
+  expect_silent(missRanger(irisWithNA, num.trees = 3L, maxiter = 3L, verbose = 0L))
+  
+  capture_output(
+    expect_no_error(
+      missRanger(irisWithNA, num.trees = 3L, verbose = 1L, maxiter = 3L)
+    )
+  )
+  
+  capture_output(
+    expect_no_error(
+      missRanger(irisWithNA, num.trees = 3L, verbose = 2L, maxiter = 3L)
+    )
+  )
 })
 
 test_that("returnOOB works", {
   imp1 <- missRanger(
-    irisWithNA, maxiter = 3L, num.trees = 50L, verbose = 0L, returnOOB = TRUE
+    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, returnOOB = TRUE
   )
-  expect_true(length(attributes(imp1)$oob) == 5L)
+  imp2 <- missRanger(
+    irisWithNA, maxiter = 3L, num.trees = 5L, verbose = 0L, returnOOB = FALSE
+  )
+  
+  expect_true(length(attributes(imp1)$oob) == ncol(iris))
+  expect_null(attributes(imp2)$oob)
 })
 
+# FORMULA PARSING
 n <- 20L
 X <- data.frame(
   x1 = seq_len(n), 
@@ -30,24 +156,77 @@ X <- data.frame(
   x4 = factor(rep(LETTERS[1:2], n %/% 2)),
   x5 = seq_len(n) > n %/% 3
 )
-X_NA <- generateNA(X, p = seq(0.2, 0.8, length.out = ncol(X)), seed = 13L)
-imp <- missRanger(X_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, seed = 1L)
 
-test_that("variable type is respected (integer might get double)", {
-  expect_true(!anyNA(imp))
-  expect_equal(sapply(imp[-1L], class), sapply(X_NA[-1L], class))
-  expect_true(class(imp[, 1L]) %in% c("integer", "numeric"))
+X_NA <- generateNA(X, p = seq(0.2, 0.8, length.out = ncol(X)), seed = 13L)
+
+test_that("formula interface works with specified left and right side", {
+  imp <- missRanger(
+    X_NA, x2 ~ x2 + x3, pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+  )
+  na_per_col <- colSums(is.na(imp$data))
+  
+  expect_equal(na_per_col[[2L]], 0L)
+  expect_true(all(na_per_col[-2L] >= 1L))
+  expect_equal(imp$to_impute, "x2")
+  expect_equal(imp$impute_by, "x2")
 })
 
-test_that("non-syntactic column names work", {
+test_that("formula interface works with unspecified right side", {
+  imp <- missRanger(
+    X_NA, x2 + x3 ~ ., pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+  )
+  na_per_col <- colSums(is.na(imp$data))
+  
+  expect_equal(unname(na_per_col[2:3]), c(0, 0))
+  expect_true(all(na_per_col[-c(2:3)] >= 1L))
+  expect_equal(imp$to_impute, c("x2", "x3"))
+  expect_equal(imp$impute_by, c("x2", "x3"))
+})
+
+test_that("formula interface works with unspecified left side", {
+  imp <- missRanger(
+    X_NA, . ~ x1, pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+  )
+  expect_true(!anyNA(imp$data))
+  expect_equal(imp$to_impute, colnames(X_NA))
+  expect_equal(imp$impute_by, "x1")
+})
+
+test_that("dropping columns on left side leave missing values", {
+  imp <- missRanger(
+    X_NA, . - x1 ~ ., pmm = 3L, num.trees = 5L, verbose = 0L, data_only = FALSE
+  )
+  expect_equal(
+    colSums(is.na(imp$data)) > 0,
+    c(x1 = TRUE, x2 = FALSE, x3 = FALSE, x4 = FALSE, x5 = FALSE)
+  )
+  xpected <- setdiff(colnames(X_NA), "x1")
+  expect_equal(imp$to_impute, xpected)
+  expect_equal(imp$impute_by, xpected)
+})
+
+test_that("dropping columns on right side has an impact", {
+  imp1 <- missRanger(
+    X_NA, . ~ . - x1, num.trees = 5L, verbose = 0L, seed = 1L, data_only = FALSE
+  )
+  imp2 <- missRanger(X_NA, num.trees = 5L, verbose = 0L, seed = 1L)
+  
+  expect_false(identical(imp1$data, imp2))
+  expect_equal(imp1$to_impute, colnames(X_NA))
+  expect_equal(imp1$impute_by, setdiff(colnames(X_NA), "x1"))
+})
+
+test_that("non-syntactic column names work with or without formula", {
   X_NA2 <- X_NA
   colnames(X_NA2) <- paste(1:5, colnames(X_NA))
-  imp2 <- missRanger(X_NA2, maxiter = 3L, num.trees = 20L, verbose = 0L, seed = 1L)
+  
+  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
+  imp2 <- missRanger(X_NA2, maxiter = 3L, num.trees = 5L, verbose = 0L, seed = 1L)
   imp3 <- missRanger(
     `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5` ~ `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5`,
     data = X_NA2, 
     maxiter = 3L, 
-    num.trees = 20L, 
+    num.trees = 5L, 
     verbose = 0L, 
     seed = 1L
   )
@@ -56,7 +235,7 @@ test_that("non-syntactic column names work", {
     . ~ `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5`,
     data = X_NA2, 
     maxiter = 3L, 
-    num.trees = 20L, 
+    num.trees = 5L, 
     verbose = 0L, 
     seed = 1L
   )
@@ -65,183 +244,40 @@ test_that("non-syntactic column names work", {
     `1 x1` + `2 x2` + `3 x3` + `4 x4` + `5 x5` ~ .,
     data = X_NA2, 
     maxiter = 3L, 
-    num.trees = 20L, 
+    num.trees = 5L, 
     verbose = 0L, 
     seed = 1L
   )
+  
+  imp6 <- missRanger(
+    . - `1 x1` ~ . - `1 x1`,
+    data = X_NA2, 
+    maxiter = 3L, 
+    num.trees = 5L, 
+    verbose = 0L, 
+    seed = 1L
+  )
+  
   expect_equal(colnames(X_NA2), colnames(imp2))
   expect_equal(imp, setNames(imp2, colnames(imp)))
   expect_equal(imp2, imp3)
   expect_equal(imp2, imp4)
   expect_equal(imp2, imp5)
   
-  # https://github.com/mayer79/missRanger/issues/51
-  ir3 <- iris
-  colnames(ir3)[2L] <- "IGHV3-43D;IGHV3-9"
-  expect_no_error(missRanger(ir3, verbose = 0L))
-})
-
-test_that("pmm.k works regarding value range in double columns", {
-  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, pmm.k = 3L)
-  expect_true(all(imp$x2 %in% X$x2))
-  
-  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, pmm.k = 0L)
-  expect_false(all(imp$x2 %in% X$x2))
-})
-
-test_that("pmm.k works regarding value range in integer columns", {
-  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, pmm.k = 3L)
-  expect_true(all(imp$x1 %in% X$x1))
-  
-  imp <- missRanger(X_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, pmm.k = 0L)
-  expect_false(all(imp$x1 %in% X$x1))
-})
-
-test_that("formula interface works with specified left and right side", {
-  imp <- missRanger(X_NA, x2 ~ x2 + x3, pmm = 3L, num.trees = 20L, verbose = 0L)
-  na_per_col <- colSums(is.na(imp))
-  
-  expect_equal(na_per_col[[2L]], 0L)
-  expect_true(all(na_per_col[-2L] >= 1L))
-})
-
-test_that("formula interface works with unspecified right side", {
-  imp <- missRanger(X_NA, x2 ~ ., pmm = 3L, num.trees = 20L, verbose = 0L)
-  na_per_col <- colSums(is.na(imp))
-  
-  expect_equal(na_per_col[[2L]], 0L)
-  expect_true(all(na_per_col[-2L] >= 1L))
-})
-
-test_that("formula interface works with unspecified left side", {
-  imp <- missRanger(X_NA, . ~ x1, pmm = 3L, num.trees = 20L, verbose = 0L)
-  expect_true(!anyNA(imp))
-})
-
-test_that("dropping columns on left side leave its missing values", {
-  imp <- missRanger(X_NA, . - x1 ~ ., pmm = 3L, num.trees = 20L, verbose = 0L)
   expect_equal(
-    colSums(is.na(imp)) > 0,
-    c(x1 = TRUE, x2 = FALSE, x3 = FALSE, x4 = FALSE, x5 = FALSE)
-  )
-})
-
-test_that("dropping columns on right side has an impact", {
-  imp1 <- missRanger(X_NA, . ~ . - x1, num.trees = 20L, verbose = 0L, seed = 1L)
-  imp2 <- missRanger(X_NA, . ~ ., num.trees = 20L, verbose = 0L, seed = 1L)
-  expect_false(identical(imp1, imp2))
-})
-
-test_that("date and datetime columns work", {
-  n <- 20L
-  Xd <- data.frame(
-    time = seq(Sys.time(), by = "1 min", length.out = n),
-    date = seq(Sys.Date(), by = "1 d", length.out = n)
-  )
-  Xd_NA <- generateNA(Xd, p = 0.3, seed = 13L)
-  
-  imp <- missRanger(Xd_NA, maxiter = 3L, num.trees = 20L, verbose = 0L, pmm.k = 0L)
-  expect_true(expect_true(!anyNA(imp)))
-  expect_equal(sapply(imp, class), sapply(Xd_NA, class))
-})
-
-test_that("mtry works", {
-  imp1 <- missRanger(
-    irisWithNA, 
-    num.trees = 30L, 
-    verbose = 0L, 
-    seed = 1L, 
-    maxiter = 3L,
-    mtry = function(m) max(1, m %/% 3)
-  )
-  
-  imp2 <- missRanger(
-    irisWithNA, 
-    num.trees = 30L, 
-    verbose = 0L, 
-    seed = 1L, 
-    mtry = 1L, 
-    maxiter = 3L
-  )
-  
-  imp3 <- missRanger(
-    irisWithNA, 
-    num.trees = 30L, 
-    verbose = 0L, 
-    seed = 1L, 
-    maxiter = 3L
-  )
-  
-  expect_equal(imp1, imp2)
-  expect_false(isTRUE(all.equal(imp1, imp3)))
-})
-
-test_that("verbose >= 1 does not produce an error", {
-  capture_output(
-    expect_no_error(
-      missRanger(
-        irisWithNA, 
-        num.trees = 3L, 
-        verbose = 1L, 
-        seed = 1L, 
-        maxiter = 1L,
-      )
-    )
-  )
-
-  capture_output(
-    expect_no_error(
-      missRanger(
-        irisWithNA, 
-        num.trees = 3L, 
-        verbose = 2L, 
-        seed = 1L, 
-        maxiter = 1L,
-      )
-    )
-  )
-})
-
-test_that("Too few case.weights give an error", {
-  expect_error(
-    missRanger(
-      irisWithNA,
-      num.trees = 3L,
-      verbose = 0L,
-      seed = 1L,
-      maxiter = 1L,
-      case.weights = 1:10
-    )
+    unname(colSums(is.na(imp6)) == 0L),
+    c(FALSE, TRUE, TRUE, TRUE, TRUE)
   )
 })
 
 test_that("Extremely wide datasets are handled", {
   # https://github.com/mayer79/missRanger/issues/50
   set.seed(1L)
-  data <- matrix(rnorm(385 * 20000), nrow = 385L, ncol = 20000L)
+  data <- as.data.frame(matrix(rnorm(385 * 20000), nrow = 385L, ncol = 20000L))
   data[5L, 5L] <- NA
-  expect_no_error(missRanger(as.data.frame(data), num.trees = 3L, verbose = 0L))
+  expect_no_error(
+    missRanger(data, num.trees = 3L, verbose = 0L, maxiter = 3, max.depth = 1)
+  )
+  rm(data)
 })
 
-test_that("Convert and revert do what they should", {
-  n <- 20L
-  X <- data.frame(
-    x1 = seq_len(n), 
-    x2 = rep(LETTERS[1:4], n %/% 4),
-    x3 = factor(rep(LETTERS[1:2], n %/% 2)),
-    x4 = seq_len(n) > n %/% 3,
-    x5 = seq(as.Date("2008-11-01"), as.Date("2008-11-21"), length.out = n)
-  )
-  X <- generateNA(X, seed = 1L)
-  conv <- convert(X)
-  reve <- revert(conv)
-  
-  expect_equal(X, reve)
-  expect_equal(
-    unname(sapply(conv$X, class)), 
-    c("integer", "factor", "factor", "factor", "numeric")
-  )
-  
-  Ximp <- missRanger(X, seed = 1L, verbose = FALSE, pmm.k = 3L)
-  expect_equal(sapply(Ximp, class), sapply(X, class))
-})

--- a/tests/testthat/test-pmm.R
+++ b/tests/testthat/test-pmm.R
@@ -36,3 +36,6 @@ test_that("pmm gives error when xtest contains NA", {
   expect_error(pmm(c(1, 1, 2), NA, ytrain = c(0, 1, 2)))
 })
 
+test_that("pmm gives error there are no complete observations in xtrain/ytrain", {
+  expect_error(pmm(xtrain = c(NA, 1), xtest = 1, ytrain = c(1, NA)))
+})

--- a/tests/testthat/test-pmm.R
+++ b/tests/testthat/test-pmm.R
@@ -27,20 +27,25 @@ test_that("pmm picks the right reference based on date vector", {
   expect_equal(pmm(xtrain, xquery, ytrain = 1:2), rep(2, 2))
 })
 
+test_that("pmm works for different types of responses", {
+  expect_equal(
+    pmm(Sys.Date(), xtest = Sys.Date(), ytrain = TRUE),
+    TRUE
+  )
+  
+  expect_equal(
+    pmm(Sys.Date(), xtest = Sys.Date(), ytrain = factor("A")),
+    factor("A")
+  )
+  
+  expect_equal(
+    pmm(2, xtest = 1, ytrain = Sys.Date()),
+    Sys.Date()
+  )
+})
+
 test_that("pmm gives error if ytrain is of wrong length", {
   expect_error(pmm(xtrain = 1, xtest = 1, ytrain = 1:2))
-})
-
-test_that("pmm works for logical y", {
-  expect_equal(pmm(1, xtest = Sys.Date(), ytrain = TRUE), TRUE)
-})
-
-test_that("pmm works for factor y", {
-  expect_equal(pmm(1, xtest = Sys.Date(), ytrain = factor("A")), factor("A"))
-})
-
-test_that("pmm works for date y", {
-  expect_equal(pmm(1, xtest = Sys.Date(), ytrain = Sys.Date()), Sys.Date())
 })
 
 test_that("pmm works with NA in xtrain", {

--- a/tests/testthat/test-pmm.R
+++ b/tests/testthat/test-pmm.R
@@ -11,45 +11,21 @@ test_that("pmm picks the right reference based on logical values", {
   )
 })
 
-test_that("pmm picks the right reference based on character values", {
+test_that("pmm picks the right reference based on factor values", {
+  xtrain <- factor(c("A", "B"))
+  xtest <- factor("B", levels = levels(xtrain))
   expect_equal(
-    pmm(xtrain = c("A", "A", "B"), xtest = "A", ytrain = c(2, 2, 4), k = 2), 2
+    pmm(xtrain = xtrain, xtest = xtest, ytrain = c(2, 0), k = 1L), 0
   )
 })
 
-test_that("pmm picks the right reference based on a factor", {
-  expect_equal(pmm(xtrain = factor(c("A", "B")), xtest = factor("C"), ytrain = 1:2), 2)
-})
-
-test_that("pmm picks the right reference based on date vector", {
-  xtrain <- as.Date(c("2018-01-01", "2018-01-02"))
-  xquery <- as.Date(c("2018-01-03", "2018-01-04"))
-  expect_equal(pmm(xtrain, xquery, ytrain = 1:2), rep(2, 2))
-})
-
-test_that("pmm works for different types of responses", {
-  expect_equal(
-    pmm(Sys.Date(), xtest = Sys.Date(), ytrain = TRUE),
-    TRUE
-  )
-  
-  expect_equal(
-    pmm(Sys.Date(), xtest = Sys.Date(), ytrain = factor("A")),
-    factor("A")
-  )
-  
-  expect_equal(
-    pmm(2, xtest = 1, ytrain = Sys.Date()),
-    Sys.Date()
-  )
+test_that("character, Dates and incompatible factors lead to an error", {
+  expect_error(pmm(xtrain = c("A", "A", "B"), xtest = "A", ytrain = c(2, 2, 4), k = 2))
+  expect_error(pmm(xtrain = factor(c("A", "B")), xtest = factor("C"), ytrain = 1:2))
 })
 
 test_that("pmm gives error if ytrain is of wrong length", {
   expect_error(pmm(xtrain = 1, xtest = 1, ytrain = 1:2))
-})
-
-test_that("pmm works with NA in xtrain", {
-  expect_equal(pmm(c(NA, 1, 2), 1, ytrain = c(0, 1, NA)), 1)
 })
 
 test_that("pmm works with NA in xtrain and NA in ytrain", {
@@ -59,3 +35,4 @@ test_that("pmm works with NA in xtrain and NA in ytrain", {
 test_that("pmm gives error when xtest contains NA", {
   expect_error(pmm(c(1, 1, 2), NA, ytrain = c(0, 1, 2)))
 })
+

--- a/tests/testthat/test-ranger.R
+++ b/tests/testthat/test-ranger.R
@@ -16,31 +16,53 @@ test_that("x/y API of ranger does not care about extra columns during prediction
   expect_equal(pred1, pred2)
 })
 
-test_that("ranger can safely predict on character feature, even for unseen values", {
+test_that("ranger can safely predict on character feature, even for unseen values or if factor", {
   ir <- transform(iris, Species = as.character(Species))
   fit <- ranger::ranger(y = ir[[1L]], x = ir["Species"], num.trees = 10L)
   
   pred1 <- predict(fit, ir[c(1L, 51L, 101L), ])$predictions
+  
   pred2 <- c(
     predict(fit, ir[1L, ])$predictions,
     predict(fit, ir[51L, ])$predictions,
     predict(fit, ir[101L, ])$predictions
   )
+
+  # At prediction time, feature is factor
+  pred3 <- predict(fit, iris[c(1L, 51L, 101L), ])$predictions
+  
   expect_equal(pred1, pred2)
+  expect_equal(pred1, pred3)
   expect_no_error(predict(fit, transform(ir[1:2, ], Species = "new value")))
+  expect_no_error(predict(fit, transform(ir[1:2, ], Species = factor("new value"))))
 })
 
-test_that("ranger safely predicts on factor feature, even with missing or new levels", {
+test_that("ranger safely predicts on factor feature, even with inconsistent levels or if character", {
   fit <- ranger::ranger(y = iris[[1L]], x = iris[5L], num.trees = 10L)
   
   pred1 <- predict(fit, iris[c(1L, 51L, 101L), ])$predictions
+  
+  # Incomplete factor levels at prediction time
   pred2 <- c(
     predict(fit, droplevels(iris[1L, ]))$predictions,
     predict(fit, droplevels(iris[51L, ]))$predictions,
     predict(fit, droplevels(iris[101L, ]))$predictions
   )
+  
+  # Character at prediction time
+  ir <- transform(iris, Species = as.character(Species))
+  pred3 <- c(
+    predict(fit, ir[1L, ])$predictions,
+    predict(fit, ir[51L, ])$predictions,
+    predict(fit, ir[101L, ])$predictions
+  )
+  
   expect_equal(pred1, pred2)
+  expect_equal(pred1, pred3)
+  
+  # Even unseen factor levels or character strings
   expect_no_error(predict(fit, transform(iris[1L, ], Species = factor("new value"))))
+  expect_no_error(predict(fit, transform(iris[1L, ], Species = "new value")))
 })
 
 test_that("storage mode of binary feature does not matter", {
@@ -122,15 +144,20 @@ test_that("date feature can be represented as number for identical results", {
   }
 })
 
-
 # STABILITY OF PREDICTION CLASSES
-test_that("ranger works with logical response, but predictions are double", {
+test_that("ranger works with logical responses, but predictions are 0 or 1", {
+  # This tests shows that predictions should be converted to logical
   y <- iris$Sepal.Length > median(iris$Sepal.Length)
   x <- iris[2:4]
   
-  fit <- ranger::ranger(y = y, x = x, num.trees = 10L)
+  fit <- ranger::ranger(y = y, x = x, num.trees = 100L)
+  pred <- predict(fit, iris)$predictions
+  
   expect_equal(fit$treetype, "Classification")
-  expect_type(predict(fit, iris[1:5, ])$predictions, "double")
+  expect_type(pred, "double")
+  expect_true(all(pred %in% c(0, 1)))
+  y[1:5] <- pred[1:5]
+  expect_type(y, "double")
 })
 
 test_that("factor responses result in factor predictions with right levels", {
@@ -138,9 +165,26 @@ test_that("factor responses result in factor predictions with right levels", {
   x <- iris[2:4]
   
   fit <- ranger::ranger(y = y, x = x, num.trees = 10L)
-  pred <- predict(fit, iris[1:5, ])$predictions
+  pred <- predict(fit, iris)$predictions
   
   expect_equal(fit$treetype, "Classification")
   expect_s3_class(pred, "factor")
   expect_equal(levels(pred), levels(y))
 })
+
+test_that("character responses are not accepted", {
+  # Shows that character responses has to be converted to character
+  y <- as.character(iris$Species)
+  x <- iris[2:4]
+  
+  expect_error(fit <- ranger::ranger(y = y, x = x, num.trees = 10L))
+})
+
+test_that("date responses are not accepted", {
+  # Shows that special classes (even if mode is numeric) are not possible
+  y <- seq.Date(as.Date("2004-01-01"), length.out = nrow(iris), by = "1 d")
+  x <- iris[2:4]
+  
+  expect_error(fit <- ranger::ranger(y = y, x = x, num.trees = 10L))
+})
+

--- a/tests/testthat/test-ranger.R
+++ b/tests/testthat/test-ranger.R
@@ -1,27 +1,146 @@
+# STABILITY OF COVARIATES
+
 test_that("x/y API of ranger does not care about feature order in x at prediction", {
-  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 10L)
+  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 40L)
+  
   pred1 <- predict(fit, iris[1:5, 2:5])
   pred2 <- predict(fit, iris[1:5, 5:2])
   expect_equal(pred1, pred2)
 })
 
 test_that("x/y API of ranger does not care about extra columns during prediction", {
-  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 10L)
+  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 40L)
+  
   pred1 <- predict(fit, iris[1:5, 2:5])
   pred2 <- predict(fit, iris[1:5, ])
   expect_equal(pred1, pred2)
 })
 
-
-test_that("ranger can safely predict on character feature", {
+test_that("ranger can safely predict on character feature, even for unseen values", {
   ir <- transform(iris, Species = as.character(Species))
-  fit <- ranger::ranger(Sepal.Length ~ ., data = ir)
+  fit <- ranger::ranger(y = ir[[1L]], x = ir["Species"], num.trees = 10L)
   
-  pred1 <- predict(fit, ir[c(1, 51, 101), ])$predictions
+  pred1 <- predict(fit, ir[c(1L, 51L, 101L), ])$predictions
   pred2 <- c(
-    predict(fit, ir[c(1), ])$predictions,
-    predict(fit, ir[c(51), ])$predictions,
-    predict(fit, ir[c(101), ])$predictions
+    predict(fit, ir[1L, ])$predictions,
+    predict(fit, ir[51L, ])$predictions,
+    predict(fit, ir[101L, ])$predictions
   )
   expect_equal(pred1, pred2)
+  expect_no_error(predict(fit, transform(ir[1:2, ], Species = "new value")))
+})
+
+test_that("ranger safely predicts on factor feature, even with missing or new levels", {
+  fit <- ranger::ranger(y = iris[[1L]], x = iris[5L], num.trees = 10L)
+  
+  pred1 <- predict(fit, iris[c(1L, 51L, 101L), ])$predictions
+  pred2 <- c(
+    predict(fit, droplevels(iris[1L, ]))$predictions,
+    predict(fit, droplevels(iris[51L, ]))$predictions,
+    predict(fit, droplevels(iris[101L, ]))$predictions
+  )
+  expect_equal(pred1, pred2)
+  expect_no_error(predict(fit, transform(iris[1L, ], Species = factor("new value"))))
+})
+
+test_that("storage mode of binary feature does not matter", {
+  y <- iris$Sepal.Length
+  x1 <- transform(iris[4:5], Species = Species == "setosa")
+  x2 <- transform(iris[4:5], Species = 1L * (Species == "setosa"))
+  x3 <- transform(iris[4:5], Species = 1.0 * (Species == "setosa"))
+  
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
+  fit3 <- ranger::ranger(y = y, x = x3, num.trees = 20L, seed = 1L)
+  
+  # Compare models
+  expect_equal(
+    predict(fit1, x1[1:5, ])$predictions,
+    predict(fit2, x2[1:5, ])$predictions
+  )
+  expect_equal(
+    predict(fit1, x1[1:5, ])$predictions,
+    predict(fit3, x3[1:5, ])$predictions
+  )
+  
+  # Compare predictions for one model applied to "wrong" data type
+  for (model in list(fit1, fit2, fit3)) {
+    expect_equal(
+      predict(model, x1[1:5, ])$predictions,
+      predict(model, x2[1:5, ])$predictions
+    )
+    expect_equal(
+      predict(model, x1[1:5, ])$predictions,
+      predict(model, x3[1:5, ])$predictions
+    )
+  }
+})
+
+test_that("integer feature can also be double", {
+  y <- iris$Sepal.Length
+  x1 <- round(iris[2L])
+  x2 <- transform(x1, Sepal.Width = as.integer(Sepal.Width))
+  
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
+  
+  # Compare models
+  expect_equal(
+    predict(fit1, x1[1:5, , drop = FALSE])$predictions,
+    predict(fit2, x2[1:5, , drop = FALSE])$predictions
+  )
+  
+  # Compare predictions for one model applied to "wrong" data type
+  for (model in list(fit1, fit2)) {
+    expect_equal(
+      predict(model, x1[1:5, , drop = FALSE])$predictions,
+      predict(model, x2[1:5, , drop = FALSE])$predictions
+    )
+  }
+})
+
+test_that("date feature can be represented as number for identical results", {
+  y <- seq(-1, 1, length.out = 100)^2
+  x1 <- data.frame(time = seq.Date(as.Date("2024-01-01"), by = "1 d", length.out = 100))
+  x2 <- transform(x1, time = as.numeric(time))
+  
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
+  
+  # Compare models
+  expect_equal(
+    predict(fit1, x1[1:5, , drop = FALSE])$predictions,
+    predict(fit2, x2[1:5, , drop = FALSE])$predictions
+  )
+  
+  # Compare predictions for one model applied to "wrong" data type
+  for (model in list(fit1, fit2)) {
+    expect_equal(
+      predict(model, x1[1:5, , drop = FALSE])$predictions,
+      predict(model, x2[1:5, , drop = FALSE])$predictions
+    )
+  }
+})
+
+
+# STABILITY OF PREDICTION CLASSES
+test_that("ranger works with logical response, but predictions are double", {
+  y <- iris$Sepal.Length > median(iris$Sepal.Length)
+  x <- iris[2:4]
+  
+  fit <- ranger::ranger(y = y, x = x, num.trees = 10L)
+  expect_equal(fit$treetype, "Classification")
+  expect_type(predict(fit, iris[1:5, ])$predictions, "double")
+})
+
+test_that("factor responses result in factor predictions with right levels", {
+  y <- iris$Species
+  x <- iris[2:4]
+  
+  fit <- ranger::ranger(y = y, x = x, num.trees = 10L)
+  pred <- predict(fit, iris[1:5, ])$predictions
+  
+  expect_equal(fit$treetype, "Classification")
+  expect_s3_class(pred, "factor")
+  expect_equal(levels(pred), levels(y))
 })

--- a/tests/testthat/test-ranger.R
+++ b/tests/testthat/test-ranger.R
@@ -1,7 +1,7 @@
 # STABILITY OF COVARIATES
 
 test_that("x/y API of ranger does not care about feature order in x at prediction", {
-  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 40L)
+  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 10L)
   
   pred1 <- predict(fit, iris[1:5, 2:5])
   pred2 <- predict(fit, iris[1:5, 5:2])
@@ -9,26 +9,30 @@ test_that("x/y API of ranger does not care about feature order in x at predictio
 })
 
 test_that("x/y API of ranger does not care about extra columns during prediction", {
-  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 40L)
+  fit <- ranger::ranger(y = iris[[1L]], x = iris[, 2:5], num.trees = 10L)
   
   pred1 <- predict(fit, iris[1:5, 2:5])
   pred2 <- predict(fit, iris[1:5, ])
   expect_equal(pred1, pred2)
 })
 
-test_that("ranger can safely predict on character feature, even for unseen values or if factor", {
+test_that("ranger can flexibly predict on feature being character at fit time", {
   ir <- transform(iris, Species = as.character(Species))
+  
+  # Fit on character
   fit <- ranger::ranger(y = ir[[1L]], x = ir["Species"], num.trees = 10L)
   
+  # Predict on character
   pred1 <- predict(fit, ir[c(1L, 51L, 101L), ])$predictions
   
+  # Predict on data with just one row
   pred2 <- c(
     predict(fit, ir[1L, ])$predictions,
     predict(fit, ir[51L, ])$predictions,
     predict(fit, ir[101L, ])$predictions
   )
 
-  # At prediction time, feature is factor
+  # Predict on factor (iris instead of ir)
   pred3 <- predict(fit, iris[c(1L, 51L, 101L), ])$predictions
   
   expect_equal(pred1, pred2)
@@ -37,9 +41,11 @@ test_that("ranger can safely predict on character feature, even for unseen value
   expect_no_error(predict(fit, transform(ir[1:2, ], Species = factor("new value"))))
 })
 
-test_that("ranger safely predicts on factor feature, even with inconsistent levels or if character", {
+test_that("ranger can flexibly predict on feature being factor at fit time", {
+  # Fit on factor
   fit <- ranger::ranger(y = iris[[1L]], x = iris[5L], num.trees = 10L)
   
+  # Predict on factor with consistent levels
   pred1 <- predict(fit, iris[c(1L, 51L, 101L), ])$predictions
   
   # Incomplete factor levels at prediction time
@@ -65,48 +71,15 @@ test_that("ranger safely predicts on factor feature, even with inconsistent leve
   expect_no_error(predict(fit, transform(iris[1L, ], Species = "new value")))
 })
 
-test_that("storage mode of binary feature does not matter", {
+test_that("ranger does not care if integer is represented as double", {
   y <- iris$Sepal.Length
-  x1 <- transform(iris[4:5], Species = Species == "setosa")
-  x2 <- transform(iris[4:5], Species = 1L * (Species == "setosa"))
-  x3 <- transform(iris[4:5], Species = 1.0 * (Species == "setosa"))
-  
-  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
-  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
-  fit3 <- ranger::ranger(y = y, x = x3, num.trees = 20L, seed = 1L)
-  
-  # Compare models
-  expect_equal(
-    predict(fit1, x1[1:5, ])$predictions,
-    predict(fit2, x2[1:5, ])$predictions
-  )
-  expect_equal(
-    predict(fit1, x1[1:5, ])$predictions,
-    predict(fit3, x3[1:5, ])$predictions
-  )
-  
-  # Compare predictions for one model applied to "wrong" data type
-  for (model in list(fit1, fit2, fit3)) {
-    expect_equal(
-      predict(model, x1[1:5, ])$predictions,
-      predict(model, x2[1:5, ])$predictions
-    )
-    expect_equal(
-      predict(model, x1[1:5, ])$predictions,
-      predict(model, x3[1:5, ])$predictions
-    )
-  }
-})
-
-test_that("integer feature can also be double", {
-  y <- iris$Sepal.Length
-  x1 <- round(iris[2L])
+  x1 <- round(iris["Sepal.Width"])  # Double
   x2 <- transform(x1, Sepal.Width = as.integer(Sepal.Width))
   
-  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
-  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 10L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 10L, seed = 1L)
   
-  # Compare models
+  # Compare predictions on "native" data type
   expect_equal(
     predict(fit1, x1[1:5, , drop = FALSE])$predictions,
     predict(fit2, x2[1:5, , drop = FALSE])$predictions
@@ -121,15 +94,38 @@ test_that("integer feature can also be double", {
   }
 })
 
-test_that("date feature can be represented as number for identical results", {
+test_that("ranger does not care if logical is represented as double", {
+  y <- iris$Sepal.Length
+  x1 <- iris["Sepal.Width"] > median(iris$Sepal.Width)
+  x2 <- transform(x1, Sepal.Width = as.double(Sepal.Width))
+  
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 10L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 10L, seed = 1L)
+  
+  # Compare predictions on "native" data type
+  expect_equal(
+    predict(fit1, x1[1:5, , drop = FALSE])$predictions,
+    predict(fit2, x2[1:5, , drop = FALSE])$predictions
+  )
+  
+  # Compare predictions for one model applied to "wrong" data type
+  for (model in list(fit1, fit2)) {
+    expect_equal(
+      predict(model, x1[1:5, , drop = FALSE])$predictions,
+      predict(model, x2[1:5, , drop = FALSE])$predictions
+    )
+  }
+})
+
+test_that("date feature work (and can be represented as number)", {
   y <- seq(-1, 1, length.out = 100)^2
   x1 <- data.frame(time = seq.Date(as.Date("2024-01-01"), by = "1 d", length.out = 100))
   x2 <- transform(x1, time = as.numeric(time))
   
-  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 20L, seed = 1L)
-  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 20L, seed = 1L)
+  fit1 <- ranger::ranger(y = y, x = x1, num.trees = 10L, seed = 1L)
+  fit2 <- ranger::ranger(y = y, x = x2, num.trees = 10L, seed = 1L)
   
-  # Compare models
+  # Compare predictions
   expect_equal(
     predict(fit1, x1[1:5, , drop = FALSE])$predictions,
     predict(fit2, x2[1:5, , drop = FALSE])$predictions
@@ -150,7 +146,7 @@ test_that("ranger works with logical responses, but predictions are 0 or 1", {
   y <- iris$Sepal.Length > median(iris$Sepal.Length)
   x <- iris[2:4]
   
-  fit <- ranger::ranger(y = y, x = x, num.trees = 100L)
+  fit <- ranger::ranger(y = y, x = x, num.trees = 50L, seed = 1L)
   pred <- predict(fit, iris)$predictions
   
   expect_equal(fit$treetype, "Classification")
@@ -173,7 +169,7 @@ test_that("factor responses result in factor predictions with right levels", {
 })
 
 test_that("character responses are not accepted", {
-  # Shows that character responses has to be converted to character
+  # Shows that character responses have to be converted to character
   y <- as.character(iris$Species)
   x <- iris[2:4]
   

--- a/vignettes/missRanger.Rmd
+++ b/vignettes/missRanger.Rmd
@@ -60,7 +60,7 @@ head(irisImputed)
 
 ### Predictive mean matching
 
-It worked, but the new values appear overly exact. To avoid this, we can activate predictive mean matching (PMM):
+It worked, but the new values appear overly exact. To avoid this, we can add predictive mean matching (PMM) to the random forest predictions:
 
 ``` {r}
 irisImputed <- missRanger(irisWithNA, pmm.k = 3, num.trees = 100, verbose = 0)
@@ -72,15 +72,15 @@ head(irisImputed)
 `missRanger()` offers many options to control the random forests grown by `ranger()`. Additional options to `ranger()` can be passed via `...`. How would we use one feature per split (mtry = 1) with 50 trees?
 
 ``` {r}
-irisImputed_et <- missRanger(
+irisImputed2 <- missRanger(
   irisWithNA, pmm.k = 3, mtry = 1, num.trees = 50, verbose = 0
 )
-head(irisImputed_et)
+head(irisImputed2)
 ```
 
-### Use in Pipe
+### Pipe
 
-{missRanger} also plays well together with the pipe:
+`missRanger()` plays well together with the pipe operator:
 
 ```{r}
 iris |>
@@ -91,10 +91,11 @@ iris |>
 
 ### Extended output
 
-Setting `data_only = FALSE` returns a "missRanger" object containing more information. Use `imp$data` to extract the imputed data.
+Setting `data_only = FALSE` returns a "missRanger" object containing more information.
 
 ```{r}
 (imp <- missRanger(irisWithNA, data_only = FALSE, verbose = 0))
+
 summary(imp)
 ```
 
@@ -107,22 +108,22 @@ This can be modified by passing a formula: The left hand side specifies the vari
 ``` {r}
 # Impute all variables with all (default behaviour)
 m <- missRanger(
-  irisWithNA, formula = . ~ ., pmm.k = 3, num.trees = 10, seed = 1, verbose = 0
+  irisWithNA, formula = . ~ ., pmm.k = 3, num.trees = 100, seed = 1, verbose = 0
 )
 
 # Don't use Species for imputation
-m <- missRanger(irisWithNA, . ~ . - Species, pmm.k = 3, num.trees = 10, verbose = 0)
+m <- missRanger(irisWithNA, . ~ . - Species, pmm.k = 3, num.trees = 100, verbose = 0)
 
 # Impute Sepal.Width by Species(?)
 m <- missRanger(
-  irisWithNA, Sepal.Width ~ Species, pmm.k = 3, num.trees = 10
+  irisWithNA, Sepal.Width ~ Species, pmm.k = 3, num.trees = 100
 )
 head(m)
 
 # Only univariate imputation was done. Why? Because Species contains missing values
 # itself and needs to appear on the lhs as well:
 m <- missRanger(
-  irisWithNA, Sepal.Width + Species ~ Species, pmm.k = 3, num.trees = 10
+  irisWithNA, Sepal.Width + Species ~ Species, pmm.k = 3, num.trees = 100
 )
 head(m)
 
@@ -132,13 +133,13 @@ m <- missRanger(irisWithNA, . ~ 1, verbose = 0)
 
 ### Speed-up things
 
-`missRanger()` is based on iteratively fitting random forests for each variable with missing values. For larger datasets, imputation can take long. Some tweaks to make things faster:
+`missRanger()` fits a random forest per variable and iteration. Thus, imputation can take long. Some tweaks to make things faster:
 
-- Use less trees, e.g., `num.trees = 20`.
-- Use smaller bootstrap samples, e.g., `sample.fraction = 0.1`.
+- Use less trees, e.g., `num.trees = 100`.
+- Use smaller bootstrap samples, e.g., `sample.fraction = 0.2`.
 - Use a smaller tree depth, e.g., `max.depth = 6`.
 - Use large leaves, e.g., `min.node.size = 100`.
-- Use less iterations, e.g., `max.iter = 2`.
+- Use less iterations, e.g., `max.iter = 3`.
 
 ### Trick: Use `case.weights` to reduce impact of rows with many missings
 
@@ -147,7 +148,7 @@ Using the `case.weights` argument, you can pass case weights to the imputation m
 ``` {r}
 m <- missRanger(
   irisWithNA,
-  num.trees = 20,
+  num.trees = 100,
   pmm.k = 3,
   seed = 5,
   verbose = 0,

--- a/vignettes/missRanger.Rmd
+++ b/vignettes/missRanger.Rmd
@@ -21,25 +21,14 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-The aim of this vignette is to introduce {missRanger} for imputation of missing values and to explain how to use it for multiple imputation.
-
-{missRanger} uses the {ranger} package [@wright] to do fast missing value imputation by chained random forest. As such, it can be used as an alternative to {missForest}, a beautiful algorithm introduced in [@stekhoven]. Basically, each variable is imputed by predictions from a random forest using all other variables as covariables. The main function `missRanger()` iterates multiple times over all variables until the average out-of-bag prediction error of the models stops to improve.
+{missRanger} uses {ranger} [@wright] for fast missing value imputation by chained random forest. As such, it is an alternative to {missForest}, a beautiful algorithm introduced in [@stekhoven]. Basically, each variable is imputed by predictions from a random forest using all other variables as covariates. The main function `missRanger()` iterates multiple times over all variables until the average out-of-bag prediction error of the models stops improving.
 
 Why should you consider {missRanger}?
 
 - It is fast.
-
-- It is flexible and intuitive to apply: E.g. calling `missRanger(data, . ~ 1)` would impute all variables univariately, `missRanger(data, Species ~ Sepal.Width)` would use `Sepal.Width` to impute `Species`.
-
-- It can deal with most realistic variable types, even dates and times without destroying the original data structure.
-
-- It combines random forest imputation with predictive mean matching. This generates realistic variability and avoids "new" values like 0.3334 in a 0-1 coded variable. Like this, `missRanger()` can be used for realistic multiple imputation scenarios, see e.g. [@rubin] for the statistical background.
-
-In the examples below, we will meet two functions from {missRanger}:
-
-- `generateNA()`: To replace values in a data set by missing values.
-
-- `missRanger()`: To impute missing values in a data frame.
+- It is flexible and intuitive to apply: E.g., calling `missRanger(data, . ~ 1)` would impute all variables univariately, `missRanger(data, Species ~ Sepal.Width)` would use `Sepal.Width` to impute `Species`.
+- It works for a variety of data types.
+- It combines random forest imputation with predictive mean matching. This avoids "new" values like 0.3334 in a 0-1 coded variable and helps to raise the variance of the imputations, which is especially important for multiple imputation.
 
 ## Installation
 
@@ -53,7 +42,7 @@ devtools::install_github("mayer79/missRanger")
 
 ## Usage
 
-We first generate a data set with about 20% missing values per column and fill them again by `missRanger()`.
+We first generate data with 20% missing values per column. Then we fill them by `missRanger()`.
 
 ``` {r}
 library(missRanger)
@@ -62,18 +51,16 @@ set.seed(84553)
 
 head(iris)
 
-# Generate data with missing values in all columns
 irisWithNA <- generateNA(iris, p = 0.2)
 head(irisWithNA)
  
-# Impute missing values with missRanger
 irisImputed <- missRanger(irisWithNA, num.trees = 100, verbose = 0)
 head(irisImputed)
 ```
 
 ### Predictive mean matching
 
-It worked! Unfortunately, the new values look somewhat unnatural due to different rounding. If we would like to avoid this, we just set the `pmm.k` argument to a positive number. All imputations done during the process are then combined with a predictive mean matching (PMM) step, leading to more natural imputations and improved distributional properties of the resulting values:
+It worked, but the new values appear overly exact. To avoid this, we can activate predictive mean matching (PMM):
 
 ``` {r}
 irisImputed <- missRanger(irisWithNA, pmm.k = 3, num.trees = 100, verbose = 0)
@@ -82,146 +69,94 @@ head(irisImputed)
 
 ### Controlling the random forests
 
-`missRanger()` offers a `...` argument to pass options to `ranger()`, e.g. `num.trees` or `min.node.size`. How would we use its "extremely randomized trees" variant with 50 trees?
+`missRanger()` offers many options to control the random forests grown by `ranger()`. Additional options to `ranger()` can be passed via `...`. How would we use one feature per split (mtry = 1) with 50 trees?
 
 ``` {r}
 irisImputed_et <- missRanger(
   irisWithNA, 
   pmm.k = 3, 
-  splitrule = "extratrees", 
+  mtry = 1,
   num.trees = 50, 
   verbose = 0
 )
 head(irisImputed_et)
 ```
 
-It is as simple!
-
 ### Use in Pipe
 
 {missRanger} also plays well together with the pipe:
 
-```r
+```{r}
 iris |>
   generateNA() |>
-  missRanger(verbose = 0) |>
+  missRanger(verbose = 0, pmm.k = 5) |>
   head()
 ```
 
-### Two output options
+### Extended output
 
-Since {missRanger} 2.4.0, setting `data_only = FALSE` allows to not just return the imputed data, but rather a "missRanger" object containing more information.
+Setting `data_only = FALSE` returns a "missRanger" object containing more information. Use `imp$data` to extract the imputed data.
 
 ```{r}
 (imp <- missRanger(irisWithNA, data_only = FALSE, verbose = 0))
-
-# Summary
 summary(imp)
 ```
 
-### Formula interface
+### Formulas
 
-By default `missRanger()` uses all columns in the data set to impute all columns with missings. To override this behaviour, you can use an intuitive formula interface: The left hand side specifies the variables to be imputed (variable names separated by a `+`), while the right hand side lists the variables used for imputation.
+By default, `missRanger()` uses all columns to impute all columns with missings.
+
+This can be modified by passing a formula: The left hand side specifies the variables to be imputed, while the right hand side lists the variables used for imputation.
 
 ``` {r}
-# Impute all variables with all (default behaviour). Note that variables without
-# missing values will be skipped from the left hand side of the formula.
+# Impute all variables with all (default behaviour)
 m <- missRanger(
   irisWithNA, formula = . ~ ., pmm.k = 3, num.trees = 10, seed = 1, verbose = 0
 )
-head(m)
 
-# Same
-m <- missRanger(irisWithNA, pmm.k = 3, num.trees = 10, seed = 1, verbose = 0)
-head(m)
-
-# Impute all variables with all except Species
+# Don't use Species for imputation
 m <- missRanger(irisWithNA, . ~ . - Species, pmm.k = 3, num.trees = 10, verbose = 0)
-head(m)
 
-# Impute Sepal.Width by Species 
+# Impute Sepal.Width by Species(?)
 m <- missRanger(
-  irisWithNA, Sepal.Width ~ Species, pmm.k = 3, num.trees = 10, verbose = 0
+  irisWithNA, Sepal.Width ~ Species, pmm.k = 3, num.trees = 10
 )
 head(m)
 
-# No success. Why? Species contains missing values and thus can only 
-# be used for imputation if it is being imputed as well
+# Only univariate imputation was done. Why? Because Species contains missing values
+# itself and needs to appear on the lhs as well:
 m <- missRanger(
-  irisWithNA, Sepal.Width + Species ~ Species, pmm.k = 3, num.trees = 10, verbose = 0
+  irisWithNA, Sepal.Width + Species ~ Species, pmm.k = 3, num.trees = 10
 )
 head(m)
 
-# Impute all variables univariatly
+# Impute all variables univariately
 m <- missRanger(irisWithNA, . ~ 1, verbose = 0)
-head(m)
 ```
 
-### Imputation takes too much time. What can I do?
+### Speed-up things
 
-`missRanger()` is based on iteratively fitting random forests for each variable with missing values. Since the underlying random forest implementation `ranger()` uses 500 trees per default, a huge number of trees might be calculated. For larger data sets, the overall process can take very long.
+`missRanger()` is based on iteratively fitting random forests for each variable with missing values. For larger datasets, imputation can take long. Some tweaks to make things faster:
 
-Here are tweaks to make things faster:
+- Use less trees, e.g., `num.trees = 20`.
+- Use smaller bootstrap samples, e.g., `sample.fraction = 0.1`.
+- Use a smaller tree depth, e.g., `max.depth = 6`.
+- Use large leaves, e.g., `min.node.size = 100`.
+- Use less iterations, e.g., `max.iter = 2`.
 
-- Use less trees, e.g. by setting `num.trees = 50`. Even one single tree might be sufficient. Typically, the number of iterations until convergence will increase with fewer trees though.
+### Trick: Use `case.weights` to reduce impact of rows with many missings
 
-- Use smaller bootstrap samples by setting e.g. `sample.fraction = 0.1`.
-
-- Use the less greedy `splitrule = "extratrees"`.
-
-- Use a low tree depth `max.depth = 6`.
-
-- Use large leafs, e.g. `min.node.size = 10000`.
-
-- Use a low `max.iter`, e.g. 1 or 2.
-
-Evaluated on a normal laptop:
-
-```r
-library(ggplot2) # for diamonds data
-dim(diamonds) # 53940    10
-
-diamonds_with_NA <- generateNA(diamonds)
-
-# Takes 270 seconds (10 * 500 trees per iteration!)
-system.time(
-  m <- missRanger(diamonds_with_NA, pmm.k = 3)
-)
-
-# Takes 19 seconds
-system.time(
-  m <- missRanger(diamonds_with_NA, pmm.k = 3, num.trees = 50)
-)
-
-# Takes 6 seconds
-system.time(
-  m <- missRanger(diamonds_with_NA, pmm.k = 3, num.trees = 1)
-)
-
-# Takes 9 seconds
-system.time(
-  m <- missRanger(diamonds_with_NA, pmm.k = 3, num.trees = 50, sample.fraction = 0.1)
-)
-```
-
-### Trick: Use `case.weights` to weight down contribution of rows with many missings
-
-Using the `case.weights` argument, you can pass case weights to the imputation models. This might be useful to weight down the contribution of rows with many missings.
+Using the `case.weights` argument, you can pass case weights to the imputation models. For instance, this allows to reduce the contribution of rows with many missings:
 
 ``` {r}
-# Count the number of non-missing values per row
-non_miss <- rowSums(!is.na(irisWithNA))
-table(non_miss)
-
-# No weighting
-m <- missRanger(irisWithNA, num.trees = 20, pmm.k = 3, seed = 5, verbose = 0)
-head(m)
-
-# Weighted by number of non-missing values per row. 
 m <- missRanger(
-  irisWithNA, num.trees = 20, pmm.k = 3, seed = 5, verbose = 0, case.weights = non_miss
+  irisWithNA,
+  num.trees = 20,
+  pmm.k = 3,
+  seed = 5,
+  verbose = 0,
+  case.weights = rowSums(!is.na(irisWithNA))
 )
-head(m)
 ```
 
 ## References

--- a/vignettes/missRanger.Rmd
+++ b/vignettes/missRanger.Rmd
@@ -73,11 +73,7 @@ head(irisImputed)
 
 ``` {r}
 irisImputed_et <- missRanger(
-  irisWithNA, 
-  pmm.k = 3, 
-  mtry = 1,
-  num.trees = 50, 
-  verbose = 0
+  irisWithNA, pmm.k = 3, mtry = 1, num.trees = 50, verbose = 0
 )
 head(irisImputed_et)
 ```

--- a/vignettes/multiple_imputation.Rmd
+++ b/vignettes/multiple_imputation.Rmd
@@ -77,6 +77,6 @@ summary(lm(Sepal.Length ~ ., data = iris))
 # F-statistic: 188.3 on 5 and 144 DF,  p-value: < 2.2e-16
 ```
 
-As expected, standard errors and p values of the multiple imputation are larger than of the original data set.
+As expected, standard errors and p values of the imputed data are larger than of the original data.
 
 ## References

--- a/vignettes/multiple_imputation.Rmd
+++ b/vignettes/multiple_imputation.Rmd
@@ -25,7 +25,7 @@ For statistical inference, extra variability introduced by imputation has to be 
 
 One of the standard approaches is to impute the dataset multiple times, generating, e.g., 10 or 100 versions of the complete data. Then, the intended analysis (t-test, linear model etc.) is performed with each of the datasets. Their results are then pooled, usually by Rubin's rule [@rubin]: Parameter *estimates* are averaged. Their *variances* are avaraged as well, and corrected upwards by adding the variance of the parameter estimates across imputations.
 
-The package {mice} [@buuren] takes care of this pooling step. The creation of multiple complete data sets can be done by {mice} or also by {missRanger}. In the latter case, in order to keep the variance of imputed values at a realistic level, we suggest to use predictive mean matching with relatively large `pmm.k` on top of the random forest imputation. 
+The package {mice} [@buuren] takes care of this pooling step. The creation of multiple complete data sets can be done by {mice} or also by {missRanger}. In the latter case, in order to keep the variance of imputed values at a more realistic level, we suggest to use predictive mean matching with relatively large `pmm.k` on top of the random forest imputation. 
 
 ## Example
 
@@ -40,7 +40,7 @@ irisWithNA <- generateNA(iris, p = c(0, 0.1, 0.1, 0.1, 0.1))
 # Generate 20 complete data sets with relatively large pmm.k
 filled <- replicate(
   20, 
-  missRanger(irisWithNA, verbose = 0, num.trees = 50, pmm.k = 10), 
+  missRanger(irisWithNA, verbose = 0, num.trees = 100, pmm.k = 10), 
   simplify = FALSE
 )
                            
@@ -50,13 +50,13 @@ models <- lapply(filled, function(x) lm(Sepal.Length ~ ., x))
 # Pool the results by mice
 summary(pooled_fit <- pool(models))
 
-#              term   estimate  std.error  statistic       df      p.value
-#       (Intercept)  2.4927868 0.34949255  7.1325891 80.75311 3.785713e-10
-#       Sepal.Width  0.4337064 0.10952987  3.9597088 78.74820 1.635231e-04
-#      Petal.Length  0.7362439 0.09201064  8.0017258 50.94966 1.453609e-10
-#       Petal.Width -0.1618100 0.18820061 -0.8597739 66.35077 3.930096e-01
-# Speciesversicolor -0.7050250 0.30099170 -2.3423403 69.11545 2.204973e-02
-#  Speciesvirginica -0.9125055 0.41666494 -2.1900224 66.90964 3.201281e-02
+#                term   estimate  std.error statistic        df      p.value
+# 1       (Intercept)  2.4600621 0.33998737  7.235746  86.25283 1.785004e-10
+# 2       Sepal.Width  0.4454417 0.10405609  4.280785  96.17676 4.406215e-05
+# 3      Petal.Length  0.7394242 0.08393401  8.809590  77.63584 2.620202e-13
+# 4       Petal.Width -0.1937151 0.17905818 -1.081856  80.36361 2.825524e-01
+# 5 Speciesversicolor -0.6785451 0.26812613 -2.530694 116.18041 1.272124e-02
+# 6  Speciesvirginica -0.8737822 0.37086417 -2.356071 110.15525 2.023735e-02
 
 # Compare with model on original data
 summary(lm(Sepal.Length ~ ., data = iris))
@@ -77,6 +77,6 @@ summary(lm(Sepal.Length ~ ., data = iris))
 # F-statistic: 188.3 on 5 and 144 DF,  p-value: < 2.2e-16
 ```
 
-As expected, standard errors and p values of the imputed data are larger than of the original data.
+As expected, inference from multiple imputation seems to be less strong than of the original data without missings.
 
 ## References

--- a/vignettes/working_with_censoring.Rmd
+++ b/vignettes/working_with_censoring.Rmd
@@ -21,15 +21,11 @@ knitr::opts_chunk$set(
 
 ## How to deal with censored variables?
 
-There is no obvious way of how to deal with survival variables as covariates in imputation models.
+There is no obvious way of how to deal with survival variables as covariates in imputation models. Options discussed in [@white] include:
 
-Options discussed in [@white] include:
-
-- Use both status variable $s$ and (censored) time variable $t$
-
-- $s$ and $\log(t)$
-
-- $\text{surv}(t)$, and, optionally $s$
+- Use the status variable $s$ and the (censored) time variable $t$.
+- Use $s$ and $\log(t)$.
+- Use $\text{surv}(t)$, and, optionally $s$.
 
 By $\text{surv}(t)$, we denote the Nelson-Aalen survival estimate at each value of $t$. The third option seems attractive as it explicitly deals with censoring information. We provide some additional details on it in the example.
 
@@ -75,12 +71,7 @@ veteran2 <- generateNA(veteran2, p = c(age = 0.1, karno = 0.1, diagtime = 0.1))
 # 2. Generate 20 complete data sets, representing "time" and "status" by "surv"
 filled <- replicate(
   20, 
-  missRanger(
-    veteran2, . ~ . - time - status, 
-    verbose = 0, 
-    pmm.k = 10, 
-    num.trees = 25
-  ), 
+  missRanger(veteran2, . ~ . - time - status, verbose = 0, pmm.k = 10, num.trees = 25), 
   simplify = FALSE
 )
 

--- a/vignettes/working_with_censoring.Rmd
+++ b/vignettes/working_with_censoring.Rmd
@@ -71,7 +71,7 @@ veteran2 <- generateNA(veteran2, p = c(age = 0.1, karno = 0.1, diagtime = 0.1))
 # 2. Generate 20 complete data sets, representing "time" and "status" by "surv"
 filled <- replicate(
   20, 
-  missRanger(veteran2, . ~ . - time - status, verbose = 0, pmm.k = 10, num.trees = 25), 
+  missRanger(veteran2, . ~ . - time - status, verbose = 0, pmm.k = 10, num.trees = 100), 
   simplify = FALSE
 )
 
@@ -81,28 +81,28 @@ models <- lapply(filled, function(x) coxph(Surv(time, status) ~ . - surv, x))
 # 4. Pool the results by mice
 summary(pooled_fit <- pool(models))
 
-               term     estimate   std.error  statistic        df      p.value
-1               trt  0.253538955 0.212912636  1.1908122 108.60558 2.363235e-01
-2 celltypesmallcell  0.815455716 0.285715626  2.8540816 113.48112 5.132019e-03
-3     celltypeadeno  1.110530627 0.311566058  3.5643505 108.55506 5.436043e-04
-4     celltypelarge  0.346762041 0.288497586  1.2019582 113.27005 2.318866e-01
-5             karno -0.030754195 0.005758037 -5.3410901  99.68585 5.837902e-07
-6          diagtime  0.001835002 0.009233708  0.1987286 107.07024 8.428519e-01
-7               age -0.006032505 0.009447786 -0.6385099 101.88961 5.245745e-01
-8             prior  0.002983767 0.023275501  0.1281935 115.27919 8.982192e-01
+#                term     estimate   std.error   statistic        df      p.value
+# 1               trt  0.264601452 0.212828712  1.24326013 110.30869 2.164079e-01
+# 2 celltypesmallcell  0.789909124 0.284989547  2.77171262 113.68488 6.516937e-03
+# 3     celltypeadeno  1.114851697 0.306765748  3.63421179 113.01225 4.210453e-04
+# 4     celltypelarge  0.356374858 0.289111314  1.23265621 112.81945 2.202666e-01
+# 5             karno -0.031939872 0.005678831 -5.62437418 111.96501 1.388135e-07
+# 6          diagtime  0.003620720 0.008929001  0.40550108  99.98576 6.859756e-01
+# 7               age -0.007503755 0.009199070 -0.81570798 108.97973 4.164464e-01
+# 8             prior  0.002002572 0.023640459  0.08470952 112.81848 9.326425e-01
 
 # Compare with the results on the original data
 summary(coxph(Surv(time, status) ~ ., veteran))$coefficients
 
-                           coef exp(coef)    se(coef)            z     Pr(>|z|)
-trt                2.946028e-01 1.3425930 0.207549604  1.419433313 1.557727e-01
-celltypesmallcell  8.615605e-01 2.3668512 0.275284474  3.129709606 1.749792e-03
-celltypeadeno      1.196066e+00 3.3070825 0.300916994  3.974738536 7.045662e-05
-celltypelarge      4.012917e-01 1.4937529 0.282688638  1.419553530 1.557377e-01
-karno             -3.281533e-02 0.9677173 0.005507757 -5.958020093 2.553121e-09
-diagtime           8.132051e-05 1.0000813 0.009136062  0.008901046 9.928981e-01
-age               -8.706475e-03 0.9913313 0.009300299 -0.936149992 3.491960e-01
-prior              7.159360e-03 1.0071850 0.023230538  0.308187441 7.579397e-01
+#                            coef exp(coef)    se(coef)            z     Pr(>|z|)
+# trt                2.946028e-01 1.3425930 0.207549604  1.419433313 1.557727e-01
+# celltypesmallcell  8.615605e-01 2.3668512 0.275284474  3.129709606 1.749792e-03
+# celltypeadeno      1.196066e+00 3.3070825 0.300916994  3.974738536 7.045662e-05
+# celltypelarge      4.012917e-01 1.4937529 0.282688638  1.419553530 1.557377e-01
+# karno             -3.281533e-02 0.9677173 0.005507757 -5.958020093 2.553121e-09
+# diagtime           8.132051e-05 1.0000813 0.009136062  0.008901046 9.928981e-01
+# age               -8.706475e-03 0.9913313 0.009300299 -0.936149992 3.491960e-01
+# prior              7.159360e-03 1.0071850 0.023230538  0.308187441 7.579397e-01
 ```
 
 ## References


### PR DESCRIPTION
This is a large PR that refactors the way missRanger() deals with variables that cannot be directly modeled by ranger(). The new implementation is slightly more picky, but also more safe.

It is an important step towards out-of-sample application (https://github.com/mayer79/missRanger/issues/58).

Here a summary:

- Columns of special type like date/time can't be imputed anymore.
- `pmm()` is more picky: `xtrain` and `xtest` must both be either numeric, logical, or factor (with identical levels).
- Now requires ranger >= 0.16.0.
- More compact vignettes.
- Many relevant `ranger()` arguments are now explicit arguments in `missRanger()` to improve tab-completion experience:
  - num.trees = 500
  - mtry = NULL
  - min.node.size = NULL
  - min.bucket = NULL
  - max.depth = NULL
  - replace = TRUE
  - sample.fraction = if (replace) 1 else 0.632
  - case.weights = NULL
  - num.threads = NULL
  - save.memory = FALSE
- Slightly more info before fitting.
