### PR TITLE
Predict num threads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ The out-of-sample algorithm works as follows:
 - For variables that can't be used, more information is printed.
 - If `keep_forests = TRUE`, the argument `data_only` is set to `FALSE` by default.
 - "missRanger" object now stores `pmm.k`.
+- `verbose` argument is passed to `ranger()` as well.
 
 # missRanger 2.5.0
 

--- a/R/missRanger.R
+++ b/R/missRanger.R
@@ -318,6 +318,7 @@ missRanger <- function(
           save.memory = save.memory,
           x = data[!v.na, completed, drop = FALSE],
           y = y,
+          verbose = verbose >= 1,
           ...
         )
 

--- a/man/predict.missRanger.Rd
+++ b/man/predict.missRanger.Rd
@@ -9,6 +9,7 @@
   newdata,
   pmm.k = object$pmm.k,
   iter = 4L,
+  num.threads = NULL,
   seed = NULL,
   verbose = 1L,
   ...
@@ -24,11 +25,14 @@ for predictive mean matching (PMM). By default the same value as during fitting.
 
 \item{iter}{Number of iterations for "hard case" rows. 0 for univariate imputation.}
 
+\item{num.threads}{Number of threads used by ranger's predict function.
+The default \code{NULL} uses all threads.}
+
 \item{seed}{Integer seed used for initial univariate imputation and PMM.}
 
 \item{verbose}{Should info be printed? (1 = yes/default, 0 for no).}
 
-\item{...}{Currently not used.}
+\item{...}{Passed to the predict function of ranger.}
 }
 \description{
 Impute missing values on \code{newdata} based on an object of class "missRanger".


### PR DESCRIPTION
- `predict()` should accept `num.threads`.
- `predict()` should pass ... to `predict.ranger()`
- `verbose` should be respected by `ranger()` and `predict.ranger()`