### PR TITLE
Fix predict empty column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,9 +15,9 @@ The out-of-sample algorithm works as follows:
 1. Impute univariately all relevant columns by randomly drawing values 
    from the original, unimputed data. This step will only impact "hard case" rows.
 2. Replace univariate imputations by predictions of random forests. This is done
-   sequentially over variablse in descending order of number of missings
-   (to minimize the impact of univariate imputations). Optionally, this is followed
-   by predictive mean matching (PMM).
+   sequentially over variables in decreasing order of missings in "hard case"
+   rows (to minimize the impact of univariate imputations).
+   Optionally, this is followed by predictive mean matching (PMM).
 3. Repeat Step 2 for "hard case" rows multiple times.
 
 ### Possibly breaking changes

--- a/R/methods.R
+++ b/R/methods.R
@@ -245,12 +245,12 @@ predict.missRanger <- function(
       }
       newdata[[v]][to_fill[, v]] <- pred
     }
-    if (j == 1L) {
+    if (j == 1L && iter > 1L) {
       to_fill <- to_fill & !easy
-      
+
       # Remove features that were missing in easy case rows only
       missing_counts <- colSums(to_fill[, to_impute, drop = FALSE])
-      to_impute <- to_impute[missing_counts > 0L]
+      to_impute <- to_impute[missing_counts > 0L] 
     }
   }
   return(newdata)

--- a/R/methods.R
+++ b/R/methods.R
@@ -219,7 +219,9 @@ predict.missRanger <- function(
     # impact of univariate imputations (here, the case above with missing forest is
     # ignored for simplicity)
     hard_counts <- colSums(to_fill[, to_impute, drop = FALSE] & !easy)
-    to_impute <- to_impute[order(hard_counts, decreasing = TRUE)]
+    ord <- order(hard_counts, decreasing = TRUE)
+    to_impute <- to_impute[ord]
+    hard_counts <- hard_counts[ord]
   }
   
   for (j in seq_len(iter)) {
@@ -247,10 +249,7 @@ predict.missRanger <- function(
     }
     if (j == 1L && iter > 1L) {
       to_fill <- to_fill & !easy
-
-      # Remove features that were missing in easy case rows only
-      missing_counts <- colSums(to_fill[, to_impute, drop = FALSE])
-      to_impute <- to_impute[missing_counts > 0L] 
+      to_impute <- to_impute[hard_counts > 0L]  # Need to fill only hard cases when j>1
     }
   }
   return(newdata)

--- a/R/methods.R
+++ b/R/methods.R
@@ -217,7 +217,6 @@ predict.missRanger <- function(
   
   for (j in seq_len(iter)) {
     for (v in to_impute) {
-      y <- newdata[[v]]
       pred <- stats::predict(
         object$forests[[v]],
         newdata[to_fill[, v], ],
@@ -232,15 +231,19 @@ predict.missRanger <- function(
           ytrain <- ytrain[!is.na(ytrain)]  # To align with OOB predictions
         }
         pred <- pmm(xtrain = xtrain, xtest = pred, ytrain = ytrain, k = pmm.k)
-      } else if (is.logical(y)) {
+      } else if (is.logical(newdata[[v]])) {
         pred <- as.logical(pred)
-      } else if (is.character(y)) {
+      } else if (is.character(newdata[[v]])) {
         pred <- as.character(pred)
       }
       newdata[[v]][to_fill[, v]] <- pred
     }
     if (j == 1L) {
       to_fill <- to_fill & !easy
+      
+      # not all features are needed anymore
+      m <- colSums(to_fill[, to_impute, drop = FALSE])
+      to_impute <- to_impute[m > 0L]
     }
   }
   return(newdata)

--- a/R/methods.R
+++ b/R/methods.R
@@ -216,9 +216,10 @@ predict.missRanger <- function(
     iter <- 1L
   } else {
     # We impute first the column with most missings in *hard case* rows to minimize
-    # impact of univariate imputations
-    missing_counts <- colSums(to_fill[, to_impute, drop = FALSE] & !easy)
-    to_impute <- to_impute[order(missing_counts, decreasing = TRUE)]
+    # impact of univariate imputations (here, the case above with missing forest is
+    # ignored for simplicity)
+    hard_counts <- colSums(to_fill[, to_impute, drop = FALSE] & !easy)
+    to_impute <- to_impute[order(hard_counts, decreasing = TRUE)]
   }
   
   for (j in seq_len(iter)) {

--- a/man/predict.missRanger.Rd
+++ b/man/predict.missRanger.Rd
@@ -52,7 +52,7 @@ The out-of-sample algorithm works as follows:
 \item Impute univariately all relevant columns by randomly drawing values
 from the original, unimputed data. This step will only impact "hard case" rows.
 \item Replace univariate imputations by predictions of random forests. This is done
-sequentially over variables in descending order of number of missings
+sequentially over variables in decreasing order of missings in "hard case" rows
 (to minimize the impact of univariate imputations). Optionally, this is followed
 by predictive mean matching (PMM).
 \item Repeat Step 2 for "hard case" rows multiple times.

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -152,6 +152,19 @@ test_that("OOS does not fail if there is all missings, even of wrong type", {
   expect_no_error(x1 <- predict(imp, new_rows, seed = 1L))
 })
 
+test_that("case works where easy case fills a complete column", {
+  imp <- missRanger(iris2, verbose = 0, seed = 1L, num.trees = 10, keep_forests = TRUE)
+  
+  X <- data.frame(
+    Sepal.Length = c(5.1, NA),
+    Sepal.Width = c(3.5, 3.4),
+    Petal.Length = c(NA, 1.4),
+    Petal.Width = c(NA, 0.3),
+    Species = factor("setosa")
+  )
+  expect_no_error(predict(imp, X))
+})
+
 n <- 200L
 
 X <- data.frame(
@@ -163,6 +176,15 @@ X <- data.frame(
 )
 
 X_NA <- generateNA(X[1:5], p = 0.2, seed = 1L)
+
+test_that("non-syntactic column names work", {
+  X_NA2 <- X_NA
+  colnames(X_NA2)[1:2] <- c("1bad name", "2 also bad")
+  
+  imp1 <- missRanger(X_NA2, num.trees = 20L, verbose = 0L, seed = 1L, keep_forests = TRUE)
+  
+  expect_equal(colnames(predict(imp1, head(X_NA2))), colnames(X_NA2))
+})
 
 test_that("OOS does not fail if there is all missings, even of wrong type (MORE TYPES)", {
   imp1 <- missRanger(
@@ -180,14 +202,5 @@ test_that("OOS does not fail if there is all missings, even of wrong type (MORE 
   xp <- list(int = "numeric", double = "numeric", char = "character", 
              fact = "factor", logi = "logical")
   expect_equal(lapply(x1, class), xp)
-})
-
-test_that("non-syntactic column names work", {
-  X_NA2 <- X_NA
-  colnames(X_NA2)[1:2] <- c("1bad name", "2 also bad")
-  
-  imp1 <- missRanger(X_NA2, num.trees = 20L, verbose = 0L, seed = 1L, keep_forests = TRUE)
-  
-  expect_equal(colnames(predict(imp1, head(X_NA2))), colnames(X_NA2))
 })
 


### PR DESCRIPTION
- Fix a problem in predict() when after the first iteration, no missings were to be filled in a column.
- Change the imputation order. Now, it is applied only in multivariate imputation. And the sorting is done based on number of missings per column, but counting only hard case rows. Only there, univariate imputation is problematic.